### PR TITLE
Use JuliaFormatter as a direct dependency

### DIFF
--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -2,19 +2,8 @@
 
 using Pkg
 using Dates
+using JuliaFormatter
 
-"""
-    ensure_juliaformatter()
-
-Ensure JuliaFormatter is available in the current environment.
-"""
-function ensure_juliaformatter()
-    if !haskey(Pkg.project().dependencies, "JuliaFormatter")
-        @info "Installing JuliaFormatter..."
-        Pkg.add("JuliaFormatter")
-    end
-    @eval using JuliaFormatter
-end
 
 """
     format_repository(repo_url::String; 
@@ -45,8 +34,6 @@ function format_repository(
     fork_user::String = "",
     working_dir::String = mktempdir(),
 )
-
-    ensure_juliaformatter()
 
     # Validate inputs
     if create_pr && isempty(fork_user)
@@ -296,8 +283,6 @@ function format_org_repositories(
     only_failing_ci::Bool = true,
     log_file::String = "",
 )
-
-    ensure_juliaformatter()
 
     # Set up logging
     if isempty(log_file)


### PR DESCRIPTION
## Summary
- Refactored formatting.jl to use JuliaFormatter as a proper dependency
- Removed dynamic installation logic since JuliaFormatter is already in Project.toml
- Follows Julia package best practices for dependency management

## Changes
This PR removes the `ensure_juliaformatter()` function that was attempting to install JuliaFormatter at runtime. Since JuliaFormatter is already listed as a dependency in Project.toml, we can simply use it directly with `using JuliaFormatter`.

### Specific changes:
1. Added `using JuliaFormatter` at the top of formatting.jl
2. Removed the `ensure_juliaformatter()` function (lines 11-17)
3. Removed calls to `ensure_juliaformatter()` in:
   - `format_repository` function
   - `format_org_repositories` function

## Benefits
- Cleaner code without runtime package installation
- JuliaFormatter is available at precompilation time
- Follows standard Julia package practices
- More reliable and predictable behavior

## Test plan
- [x] Verified that JuliaFormatter loads correctly
- [x] Tested that formatting functions are still accessible
- [x] Confirmed all dependencies are properly resolved

🤖 Generated with [Claude Code](https://claude.ai/code)