### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,7 +19,8 @@ makedocs(;
         edit_link = "main",
         assets = ["assets/favicon.ico"]
     ),
-    pages = ["Home" => "index.md",
+    pages = [
+        "Home" => "index.md",
         "Formatting Maintenance" => "formatting.md",
         "Version Bumping" => "version_bumping.md",
         "Compat Bumping" => "compat_bumping.md",
@@ -29,7 +30,8 @@ makedocs(;
         "Import Timing Analysis" => "import_timing_analysis.md",
         "Explicit Imports Fixing" => "explicit_imports_fixing.md",
         "Documentation Cleanup" => "documentation_cleanup.md",
-        "Multiprocess Testing" => "multiprocess_testing.md"]
+        "Multiprocess Testing" => "multiprocess_testing.md",
+    ]
 )
 
 deploydocs(; repo = "github.com/SciML/OrgMaintenanceScripts.jl", devbranch = "main")

--- a/examples/import_timing_analysis_example.jl
+++ b/examples/import_timing_analysis_example.jl
@@ -16,14 +16,14 @@ try
 
     println("Analysis completed for: $(report.repo)")
     println("Package: $(report.package_name)")
-    println("Total import time: $(round(report.total_import_time, digits=2)) seconds")
+    println("Total import time: $(round(report.total_import_time, digits = 2)) seconds")
     println("Summary: $(report.summary)")
 
     if !isempty(report.major_contributors)
         println("\nTop import contributors:")
         for (i, timing) in enumerate(report.major_contributors[1:min(5, end)])
             local_marker = timing.is_local ? " (LOCAL)" : ""
-            println("  $i. $(timing.package_name)$local_marker - $(round(timing.total_time, digits=2))s")
+            println("  $i. $(timing.package_name)$local_marker - $(round(timing.total_time, digits = 2))s")
         end
     end
 
@@ -64,26 +64,28 @@ println("- raw_output: Raw @time_imports output for debugging")
 # Example 3: Organization analysis (demonstration only)
 println("\n=== Example 3: Organization Analysis (Demo) ===")
 println("To analyze an entire organization:")
-println("""
-    # Set up authentication
-    github_token = ENV["GITHUB_TOKEN"]
-    
-    # Analyze a small organization or subset
-    results = analyze_org_import_timing("MyOrg", 
-        auth_token=github_token,
-        output_dir="import_timing_reports",
-        max_repos=5  # Limit for testing
-    )
-    
-    # Find slowest packages
-    slowest = sort([(name, r.total_import_time) for (name, r) in results], 
-                   by=x->x[2], rev=true)
-    
-    println("Slowest packages:")
-    for (name, time) in slowest[1:5]
-        println("\$name: \$(round(time, digits=2))s")
-    end
-""")
+println(
+    """
+        # Set up authentication
+        github_token = ENV["GITHUB_TOKEN"]
+        
+        # Analyze a small organization or subset
+        results = analyze_org_import_timing("MyOrg", 
+            auth_token=github_token,
+            output_dir="import_timing_reports",
+            max_repos=5  # Limit for testing
+        )
+        
+        # Find slowest packages
+        slowest = sort([(name, r.total_import_time) for (name, r) in results], 
+                       by=x->x[2], rev=true)
+        
+        println("Slowest packages:")
+        for (name, time) in slowest[1:5]
+            println("\$name: \$(round(time, digits=2))s")
+        end
+    """
+)
 
 # Example 4: Interpreting results and optimization strategies
 println("\n=== Example 4: Import Time Optimization Strategies ===")

--- a/examples/invalidation_analysis_example.jl
+++ b/examples/invalidation_analysis_example.jl
@@ -55,22 +55,24 @@ println(custom_test_script)
 # Example 3: Organization analysis (demonstration only)
 println("\n=== Example 3: Organization Analysis (Demo) ===")
 println("To analyze an entire organization:")
-println("""
-    # Set up authentication
-    github_token = ENV["GITHUB_TOKEN"]
-    
-    # Analyze a small organization or subset
-    results = analyze_org_invalidations("MyOrg", 
-        auth_token=github_token,
-        output_dir="invalidation_reports",
-        max_repos=5  # Limit for testing
-    )
-    
-    # Print summary
-    for (repo, report) in results
-        println("\$repo: \$(report.total_invalidations) invalidations")
-    end
-""")
+println(
+    """
+        # Set up authentication
+        github_token = ENV["GITHUB_TOKEN"]
+        
+        # Analyze a small organization or subset
+        results = analyze_org_invalidations("MyOrg", 
+            auth_token=github_token,
+            output_dir="invalidation_reports",
+            max_repos=5  # Limit for testing
+        )
+        
+        # Print summary
+        for (repo, report) in results
+            println("\$repo: \$(report.total_invalidations) invalidations")
+        end
+    """
+)
 
 # Example 4: Understanding the report structure
 println("\n=== Example 4: Report Structure ===")

--- a/examples/version_check_example.jl
+++ b/examples/version_check_example.jl
@@ -36,16 +36,18 @@ end
 # Example 4: Demonstrate parallel fixing (dry run)
 println("\n=== Example 4: Parallel fixing demonstration ===")
 println("To fix version checks in parallel across an organization:")
-println("""
-    # Set your GitHub token
-    github_token = ENV["GITHUB_TOKEN"]
-    
-    # Fix all obsolete version checks in the SciML organization
-    results = fix_org_version_checks_parallel("SciML", 4; 
-        github_token=github_token,
-        min_version=v"1.10"
-    )
-""")
+println(
+    """
+        # Set your GitHub token
+        github_token = ENV["GITHUB_TOKEN"]
+        
+        # Fix all obsolete version checks in the SciML organization
+        results = fix_org_version_checks_parallel("SciML", 4; 
+            github_token=github_token,
+            min_version=v"1.10"
+        )
+    """
+)
 
 println("\nNote: The parallel fixing will create PRs to remove obsolete version checks.")
 println("Each PR will be handled by Claude to ensure proper code changes.")

--- a/src/compat_bumper.jl
+++ b/src/compat_bumper.jl
@@ -66,7 +66,7 @@ function get_available_compat_updates(project_path::String)
                 push!(updates, CompatUpdate(pkg_name, current_compat, latest_version, true))
             end
         catch e
-            @warn "Failed to check updates for $pkg_name" exception=e
+            @warn "Failed to check updates for $pkg_name" exception = e
         end
     end
 
@@ -215,7 +215,7 @@ function bump_compat_entry(project_path::String, package_name::String, new_versi
         TOML.print(io, project)
     end
 
-    @info "Updated $package_name compat to $new_compat"
+    return @info "Updated $package_name compat to $new_compat"
 end
 
 """
@@ -240,11 +240,13 @@ If tests pass, optionally create a PR.
 
   - `(success::Bool, message::String, pr_url::Union{String,Nothing}, bumped_packages::Vector{String})`
 """
-function bump_compat_and_test(repo_path::String;
+function bump_compat_and_test(
+        repo_path::String;
         package_name::Union{String, Nothing} = nothing,
         bump_all::Bool = false,
         create_pr::Bool = true,
-        fork_user::String = "")
+        fork_user::String = ""
+    )
     if create_pr && isempty(fork_user)
         return (false, "fork_user must be provided when create_pr=true", nothing, String[])
     end
@@ -265,8 +267,10 @@ function bump_compat_and_test(repo_path::String;
     if !isnothing(package_name)
         updates = filter(u -> u.package_name == package_name, updates)
         if isempty(updates)
-            return (false, "No major version update available for $package_name",
-                nothing, String[])
+            return (
+                false, "No major version update available for $package_name",
+                nothing, String[],
+            )
         end
     end
 
@@ -290,7 +294,7 @@ function bump_compat_and_test(repo_path::String;
             bump_compat_entry(project_path, update.package_name, update.latest_version)
             push!(bumped_packages, update.package_name)
         catch e
-            @error "Failed to bump $(update.package_name)" exception=e
+            @error "Failed to bump $(update.package_name)" exception = e
         end
     end
 
@@ -303,7 +307,7 @@ function bump_compat_and_test(repo_path::String;
         try
             run(`julia --project=. -e "using Pkg; Pkg.update()"`)
         catch e
-            @warn "Failed to update manifest" exception=e
+            @warn "Failed to update manifest" exception = e
         end
     end
 
@@ -397,7 +401,7 @@ function run_package_tests(repo_path::String; timeout_minutes::Int = 30)
             end
         end
     catch e
-        @error "Error running tests" exception=e
+        @error "Error running tests" exception = e
         return false
     end
 end
@@ -408,7 +412,7 @@ end
 Create a pull request for compat updates.
 """
 function create_compat_pr(repo_path::String, bumped_packages::Vector{String}, fork_user::String)
-    cd(repo_path) do
+    return cd(repo_path) do
         # Get repo info
         remote_url = strip(read(`git remote get-url origin`, String))
         m = match(r"github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?$", remote_url)
@@ -462,12 +466,13 @@ function create_compat_pr(repo_path::String, bumped_packages::Vector{String}, fo
         try
             pr_output = read(
                 `gh pr create --repo $org/$repo --head $fork_user:$current_branch --title "$pr_title" --body-file pr_body.txt`,
-                String)
+                String
+            )
             rm("pr_body.txt")
             return strip(pr_output)
         catch e
             rm("pr_body.txt")
-            @error "Failed to create PR" exception=e
+            @error "Failed to create PR" exception = e
             return nothing
         end
     end
@@ -497,12 +502,14 @@ This function supports repositories with subpackages in the /lib directory.
 
   - `(success::Bool, message::String, pr_url::Union{String,Nothing}, bumped_info::Dict)`
 """
-function bump_compat_and_test_all(repo_path::String;
+function bump_compat_and_test_all(
+        repo_path::String;
         package_name::Union{String, Nothing} = nothing,
         bump_all::Bool = false,
         create_pr::Bool = true,
         fork_user::String = "",
-        include_subpackages::Bool = true)
+        include_subpackages::Bool = true
+    )
     if create_pr && isempty(fork_user)
         return (false, "fork_user must be provided when create_pr=true", nothing, Dict())
     end
@@ -565,7 +572,7 @@ function bump_compat_and_test_all(repo_path::String;
                 push!(bumped_packages, update.package_name)
                 total_bumped += 1
             catch e
-                @error "Failed to bump $(update.package_name) in $rel_path" exception=e
+                @error "Failed to bump $(update.package_name) in $rel_path" exception = e
             end
         end
 
@@ -586,7 +593,7 @@ function bump_compat_and_test_all(repo_path::String;
                 @info "Updating manifest for $rel_path"
                 run(`julia --project=. -e "using Pkg; Pkg.update()"`)
             catch e
-                @warn "Failed to update manifest for $rel_path" exception=e
+                @warn "Failed to update manifest for $rel_path" exception = e
             end
         end
     end
@@ -645,8 +652,10 @@ Create a pull request for compat updates across multiple Project.toml files.
 """
 function create_compat_pr_multi(
         repo_path::String, bumped_info::Dict{
-            String, Vector{String}}, fork_user::String)
-    cd(repo_path) do
+            String, Vector{String},
+        }, fork_user::String
+    )
+    return cd(repo_path) do
         # Get repo info
         remote_url = strip(read(`git remote get-url origin`, String))
         m = match(r"github\.com[/:]([^/]+)/([^/]+?)(?:\.git)?$", remote_url)
@@ -706,12 +715,13 @@ function create_compat_pr_multi(
         try
             pr_output = read(
                 `gh pr create --repo $org/$repo --head $fork_user:$current_branch --title "$pr_title" --body-file pr_body.txt`,
-                String)
+                String
+            )
             rm("pr_body.txt")
             return strip(pr_output)
         catch e
             rm("pr_body.txt")
-            @error "Failed to create PR" exception=e
+            @error "Failed to create PR" exception = e
             return nothing
         end
     end
@@ -745,14 +755,16 @@ This function now supports repositories with subpackages in /lib directories.
 
   - `(successes::Vector{String}, failures::Vector{String}, pr_urls::Vector{String})`
 """
-function bump_compat_org_repositories(org::String = "SciML";
+function bump_compat_org_repositories(
+        org::String = "SciML";
         package_name::Union{String, Nothing} = nothing,
         bump_all::Bool = false,
         create_pr::Bool = true,
         fork_user::String = "",
         limit::Int = 100,
         log_file::String = "",
-        include_subpackages::Bool = true)
+        include_subpackages::Bool = true
+    )
     if create_pr && isempty(fork_user)
         error("fork_user must be provided when create_pr=true")
     end
@@ -764,7 +776,7 @@ function bump_compat_org_repositories(org::String = "SciML";
         log_file = joinpath(log_dir, "compat_bump_$(org)_$(Dates.format(now(), "yyyy-mm-dd_HHMMSS")).log")
     end
 
-    @info "Starting organization-wide compat bumping" org=org log_file=log_file
+    @info "Starting organization-wide compat bumping" org = org log_file = log_file
 
     # Get repositories
     @info "Fetching repositories from $org..."
@@ -773,7 +785,7 @@ function bump_compat_org_repositories(org::String = "SciML";
         output = read(cmd, String)
         filter(!isempty, split(strip(output), '\n'))
     catch e
-        @error "Failed to fetch repositories" exception=e
+        @error "Failed to fetch repositories" exception = e
         return (String[], String[], String[])
     end
 
@@ -797,7 +809,7 @@ function bump_compat_org_repositories(org::String = "SciML";
         println(log_io)
 
         for (i, repo) in enumerate(repos)
-            @info "Processing repository" repo=repo progress="$i/$(length(repos))"
+            @info "Processing repository" repo = repo progress = "$i/$(length(repos))"
             println(log_io, "\n[$i/$(length(repos))] Processing $repo...")
 
             repo_url = "https://github.com/$org/$repo.git"
@@ -820,8 +832,8 @@ function bump_compat_org_repositories(org::String = "SciML";
                 if use_multi
                     # Use multi-project aware function
                     success, message,
-                    pr_url,
-                    bumped_info = bump_compat_and_test_all(
+                        pr_url,
+                        bumped_info = bump_compat_and_test_all(
                         repo_path;
                         package_name = package_name,
                         bump_all = bump_all,
@@ -854,8 +866,8 @@ function bump_compat_org_repositories(org::String = "SciML";
                 else
                     # Use original single-project function
                     success, message,
-                    pr_url,
-                    bumped = bump_compat_and_test(
+                        pr_url,
+                        bumped = bump_compat_and_test(
                         repo_path;
                         package_name = package_name,
                         bump_all = bump_all,
@@ -915,7 +927,7 @@ function bump_compat_org_repositories(org::String = "SciML";
 
     rm(working_dir; force = true, recursive = true)
 
-    @info "Organization compat bumping complete" successes=length(successes) failures=length(failures) prs=length(pr_urls)
+    @info "Organization compat bumping complete" successes = length(successes) failures = length(failures) prs = length(pr_urls)
 
     return (successes, failures, pr_urls)
 end

--- a/src/documentation_cleanup.jl
+++ b/src/documentation_cleanup.jl
@@ -85,20 +85,22 @@ The function identifies and removes:
 The latest version is automatically detected by parsing semantic version numbers
 from directory names matching the pattern `v\\d+\\.\\d+\\.\\d+`.
 """
-function cleanup_gh_pages_docs(repo_path::String; 
-                               preserve_latest::Bool=true,
-                               dry_run::Bool=false,
-                               size_threshold_mb::Float64=5.0)
-    
+function cleanup_gh_pages_docs(
+        repo_path::String;
+        preserve_latest::Bool = true,
+        dry_run::Bool = false,
+        size_threshold_mb::Float64 = 5.0
+    )
+
     # Validate inputs
     if !isdir(repo_path)
         throw(ArgumentError("Repository path does not exist: $repo_path"))
     end
-    
+
     if !isdir(joinpath(repo_path, ".git"))
         throw(ArgumentError("Not a Git repository: $repo_path"))
     end
-    
+
     # Initialize result tracking
     result = (
         files_removed = 0,
@@ -107,12 +109,12 @@ function cleanup_gh_pages_docs(repo_path::String;
         versions_cleaned = String[],
         preserved_version = nothing,
         success = true,  # Default to success unless error occurs
-        error_message = nothing
+        error_message = nothing,
     )
-    
+
     # Track if we should return early
     early_return_result = nothing
-    
+
     try
         cd(repo_path) do
             # Check if gh-pages branch exists
@@ -121,25 +123,25 @@ function cleanup_gh_pages_docs(repo_path::String;
                 early_return_result = result
                 return
             end
-            
+
             # Store current branch to restore later
             current_branch = _get_current_branch()
-            
+
             try
                 # Switch to gh-pages branch
                 _run_git_command(`checkout gh-pages`)
-                
+
                 # Find latest version to preserve
                 latest_version = preserve_latest ? _find_latest_version() : nothing
-                
+
                 if preserve_latest && latest_version !== nothing
                     @info "Preserving latest version: $latest_version"
                 end
-                
+
                 # Find large files and old versions to clean
                 large_files = _find_large_files(size_threshold_mb)
                 old_versions = _find_old_versions(latest_version)
-                
+
                 if dry_run
                     sim_result = _simulate_cleanup(large_files, old_versions)
                     early_return_result = (
@@ -150,14 +152,14 @@ function cleanup_gh_pages_docs(repo_path::String;
                         preserved_version = latest_version,
                         success = true,
                         error_message = nothing,
-                        dry_run = true
+                        dry_run = true,
                     )
                     return
                 end
-                
+
                 # Perform actual cleanup
                 cleanup_stats = _perform_cleanup(large_files, old_versions, latest_version)
-                
+
                 # Commit changes
                 if cleanup_stats.files_removed > 0
                     _run_git_command(`add -A`)
@@ -167,13 +169,13 @@ Removed $(cleanup_stats.files_removed) files ($(round(cleanup_stats.size_saved_m
 $(preserve_latest ? "Preserved: $latest_version" : "Removed all versions")
 
 Auto-generated cleanup to reduce repository size."`)
-                    
+
                     # Aggressive garbage collection
                     _run_git_command(`gc --prune=now --aggressive`)
                 end
-                
-                result = merge(result, cleanup_stats, (success=true,))
-                
+
+                result = merge(result, cleanup_stats, (success = true,))
+
             finally
                 # Always restore original branch
                 try
@@ -183,17 +185,17 @@ Auto-generated cleanup to reduce repository size."`)
                 end
             end
         end
-        
+
     catch e
-        result = merge(result, (success=false, error_message=string(e)))
-        @error "Cleanup failed" exception=e
+        result = merge(result, (success = false, error_message = string(e)))
+        @error "Cleanup failed" exception = e
     end
-    
+
     # Return early result if set (for dry-run or no gh-pages cases)
     if early_return_result !== nothing
         return early_return_result
     end
-    
+
     return result
 end
 
@@ -226,30 +228,32 @@ println("\\n\$(analysis.analysis)")
 ```
 """
 function analyze_gh_pages_bloat(repo_path::String)
-    cd(repo_path) do
+    return cd(repo_path) do
         if !_branch_exists("gh-pages")
-            return (total_size_mb=0.0, large_files=[], versions=[], 
-                   latest_version=nothing, analysis="No gh-pages branch")
+            return (
+                total_size_mb = 0.0, large_files = [], versions = [],
+                latest_version = nothing, analysis = "No gh-pages branch",
+            )
         end
-        
+
         current_branch = _get_current_branch()
-        
+
         try
             _run_git_command(`checkout gh-pages`)
-            
+
             # Analyze current state
             large_files = _find_large_files(1.0)  # Files > 1MB
             versions = _find_all_versions()
             total_size = isempty(large_files) ? 0.0 : sum(file.size_mb for file in large_files)
-            
+
             return (
                 total_size_mb = total_size,
                 large_files = large_files,
                 versions = versions,
                 latest_version = _find_latest_version(),
-                analysis = _generate_analysis_report(large_files, versions)
+                analysis = _generate_analysis_report(large_files, versions),
             )
-            
+
         finally
             _run_git_command(`checkout $current_branch`)
         end
@@ -290,46 +294,54 @@ total_savings = sum(r.size_saved_mb for r in results if r.success)
 println("Organization could save \$(total_savings) MB")
 ```
 """
-function cleanup_org_gh_pages_docs(org_repos::Vector{String}; 
-                                  preserve_latest::Bool=true,
-                                  dry_run::Bool=false, 
-                                  size_threshold_mb::Float64=5.0,
-                                  working_dir::String=mktempdir())
-    
+function cleanup_org_gh_pages_docs(
+        org_repos::Vector{String};
+        preserve_latest::Bool = true,
+        dry_run::Bool = false,
+        size_threshold_mb::Float64 = 5.0,
+        working_dir::String = mktempdir()
+    )
+
     results = []
-    
+
     for repo_url in org_repos
         repo_name = split(basename(repo_url), ".")[1]  # Extract repo name
         repo_path = joinpath(working_dir, repo_name)
-        
+
         try
             @info "Processing repository: $repo_name"
-            
+
             # Clone repository if not already present
             if !isdir(repo_path)
                 run(`git clone $repo_url $repo_path`)
             end
-            
+
             # Run cleanup
-            result = cleanup_gh_pages_docs(repo_path; 
-                                         preserve_latest=preserve_latest,
-                                         dry_run=dry_run, 
-                                         size_threshold_mb=size_threshold_mb)
-            
-            result_with_repo = merge(result, (repository=repo_name, repo_url=repo_url))
+            result = cleanup_gh_pages_docs(
+                repo_path;
+                preserve_latest = preserve_latest,
+                dry_run = dry_run,
+                size_threshold_mb = size_threshold_mb
+            )
+
+            result_with_repo = merge(result, (repository = repo_name, repo_url = repo_url))
             push!(results, result_with_repo)
-            
+
             if result.success && result.size_saved_mb > 0
                 @info "Repository $repo_name: $(result.size_saved_mb) MB $(dry_run ? "would be" : "") saved"
             end
-            
+
         catch e
-            @error "Failed to process repository $repo_name" exception=e
-            push!(results, (repository=repo_name, repo_url=repo_url, success=false, 
-                          error_message=string(e), size_saved_mb=0.0))
+            @error "Failed to process repository $repo_name" exception = e
+            push!(
+                results, (
+                    repository = repo_name, repo_url = repo_url, success = false,
+                    error_message = string(e), size_saved_mb = 0.0,
+                )
+            )
         end
     end
-    
+
     return results
 end
 
@@ -353,7 +365,7 @@ function _get_current_branch()
 end
 
 function _run_git_command(cmd)
-    run(`git $cmd`)
+    return run(`git $cmd`)
 end
 
 function _find_latest_version()
@@ -365,13 +377,13 @@ function _find_latest_version()
                 push!(versions, item)
             end
         end
-        
+
         if isempty(versions)
             return nothing
         end
-        
+
         # Sort versions and return latest
-        sort!(versions, by=v -> VersionNumber(v[2:end]), rev=true)
+        sort!(versions, by = v -> VersionNumber(v[2:end]), rev = true)
         return versions[1]
     catch
         return nothing
@@ -381,28 +393,30 @@ end
 function _find_large_files(threshold_mb::Float64)
     large_files = []
     threshold_bytes = threshold_mb * 1024 * 1024
-    
+
     # Use git to find large objects in current branch
     try
         objects_output = readchomp(`git rev-list --objects HEAD`)
-        
+
         for line in split(objects_output, '\n')
-            parts = split(line, ' ', limit=2)
+            parts = split(line, ' ', limit = 2)
             if length(parts) >= 2
                 obj_hash = parts[1]
                 file_path = parts[2]
-                
+
                 # Get object size
                 try
                     size_output = readchomp(`git cat-file -s $obj_hash`)
                     size_bytes = parse(Int, size_output)
-                    
+
                     if size_bytes > threshold_bytes
-                        push!(large_files, (
-                            path = file_path,
-                            size_mb = size_bytes / (1024 * 1024),
-                            hash = obj_hash
-                        ))
+                        push!(
+                            large_files, (
+                                path = file_path,
+                                size_mb = size_bytes / (1024 * 1024),
+                                hash = obj_hash,
+                            )
+                        )
                     end
                 catch
                     continue
@@ -410,84 +424,86 @@ function _find_large_files(threshold_mb::Float64)
             end
         end
     catch e
-        @warn "Could not analyze large files" exception=e
+        @warn "Could not analyze large files" exception = e
     end
-    
+
     return large_files
 end
 
-function _find_old_versions(preserve_version=nothing)
+function _find_old_versions(preserve_version = nothing)
     old_versions = String[]
-    
+
     for item in readdir(".")
         if isdir(item)
             # Version directories
             if match(r"^v\d+\.\d+\.\d+$", item) !== nothing && item != preserve_version
                 push!(old_versions, item)
-            # Preview/dev directories  
+                # Preview/dev directories
             elseif item in ["dev", "previews"] || startswith(item, "preview")
                 push!(old_versions, item)
             end
         end
     end
-    
+
     return old_versions
 end
 
 function _find_all_versions()
     versions = String[]
-    
+
     for item in readdir(".")
         if isdir(item) && match(r"^v\d+\.\d+\.\d+$", item) !== nothing
             push!(versions, item)
         end
     end
-    
-    return sort(versions, by=v -> VersionNumber(v[2:end]), rev=true)
+
+    return sort(versions, by = v -> VersionNumber(v[2:end]), rev = true)
 end
 
 function _simulate_cleanup(large_files, old_versions)
     total_size_mb = if isempty(large_files) || isempty(old_versions)
         0.0
     else
-        sum(file.size_mb for file in large_files if 
-            any(startswith(file.path, version * "/") for version in old_versions))
+        sum(
+            file.size_mb for file in large_files if
+                any(startswith(file.path, version * "/") for version in old_versions)
+        )
     end
-    
+
     @info "DRY RUN - Would remove:"
-    @info "  $(length(large_files)) large files ($(round(total_size_mb, digits=1)) MB)"
+    @info "  $(length(large_files)) large files ($(round(total_size_mb, digits = 1)) MB)"
     @info "  $(length(old_versions)) old version directories"
-    
+
     for version in old_versions
         @info "    - $version/"
     end
-    
+
     return (
         files_removed = length(large_files),
         dirs_removed = length(old_versions),
         size_saved_mb = total_size_mb,
         versions_cleaned = old_versions,
-        success = true
+        success = true,
     )
 end
 
 function _perform_cleanup(large_files, old_versions, preserve_version)
     files_removed = 0
     size_saved_mb = 0.0
-    
+
     # Calculate size savings from large files in removed directories first
     for file in large_files
         if any(startswith(file.path, version * "/") for version in old_versions)
             size_saved_mb += file.size_mb
         end
     end
-    
+
     # Remove old version directories
     for version in old_versions
         if isdir(version)
             # Count files before removing and add directory size estimate
             files_in_dir = _count_files_recursively(version)
-            
+
             # Estimate size from directory (if not already counted from large files)
             try
                 dir_size_bytes = _get_directory_size(version)
@@ -502,19 +518,19 @@ function _perform_cleanup(large_files, old_versions, preserve_version)
                     size_saved_mb += 0.1  # Minimum 0.1 MB estimate
                 end
             end
-            
-            rm(version, recursive=true, force=true)
+
+            rm(version, recursive = true, force = true)
             files_removed += files_in_dir
             @info "Removed directory: $version"
         end
     end
-    
+
     return (
         files_removed = files_removed,
         dirs_removed = length(old_versions),
         size_saved_mb = size_saved_mb,
         versions_cleaned = old_versions,
-        preserved_version = preserve_version
+        preserved_version = preserve_version,
     )
 end
 
@@ -558,23 +574,23 @@ end
 
 function _generate_analysis_report(large_files, versions)
     report = []
-    
+
     push!(report, "Documentation Bloat Analysis")
-    push!(report, "=" ^ 30)
+    push!(report, "="^30)
     push!(report, "Total versions found: $(length(versions))")
     push!(report, "Large files (>1MB): $(length(large_files))")
-    
+
     if !isempty(large_files)
         total_size = isempty(large_files) ? 0.0 : sum(file.size_mb for file in large_files)
-        push!(report, "Total size of large files: $(round(total_size, digits=1)) MB")
+        push!(report, "Total size of large files: $(round(total_size, digits = 1)) MB")
         push!(report, "")
         push!(report, "Largest files:")
-        
-        sorted_files = sort(large_files, by=f -> f.size_mb, rev=true)
+
+        sorted_files = sort(large_files, by = f -> f.size_mb, rev = true)
         for file in sorted_files[1:min(10, length(sorted_files))]
-            push!(report, "  $(round(file.size_mb, digits=1)) MB - $(file.path)")
+            push!(report, "  $(round(file.size_mb, digits = 1)) MB - $(file.path)")
         end
     end
-    
+
     return join(report, "\n")
 end

--- a/src/explicit_imports_fixer.jl
+++ b/src/explicit_imports_fixer.jl
@@ -58,7 +58,7 @@ function run_explicit_imports_check(package_path::String; verbose = true)
     pkg_name = project_toml["name"]
 
     # Create a temporary environment to load and check the package
-    mktempdir() do tmpdir
+    return mktempdir() do tmpdir
         # Copy the package to temp directory to avoid modifying the original during checks
         test_path = joinpath(tmpdir, "test_package")
         cp(package_path, test_path)
@@ -98,17 +98,19 @@ function run_explicit_imports_check(package_path::String; verbose = true)
 
                     # Parse issues from the result
                     if hasproperty(missing_result, :errors) &&
-                       !isempty(missing_result.errors)
+                            !isempty(missing_result.errors)
                         for error in missing_result.errors
                             # Extract module and symbol information
                             if hasproperty(error, :name) && hasproperty(error, :source)
-                                push!(all_issues,
+                                push!(
+                                    all_issues,
                                     (
                                         type = :missing_import,
                                         module_name = string(error.source),
                                         symbol = string(error.name),
-                                        line = "$(error.source).$(error.name) is not explicitly imported"
-                                    ))
+                                        line = "$(error.source).$(error.name) is not explicitly imported",
+                                    )
+                                )
                             end
                         end
                     end
@@ -130,12 +132,14 @@ function run_explicit_imports_check(package_path::String; verbose = true)
                     if hasproperty(stale_result, :errors) && !isempty(stale_result.errors)
                         for error in stale_result.errors
                             if hasproperty(error, :name)
-                                push!(all_issues,
+                                push!(
+                                    all_issues,
                                     (
                                         type = :unused_import,
                                         symbol = string(error.name),
-                                        line = "$(error.name) is explicitly imported but not used"
-                                    ))
+                                        line = "$(error.name) is explicitly imported but not used",
+                                    )
+                                )
                             end
                         end
                     end
@@ -213,36 +217,42 @@ function parse_explicit_imports_output(output::String)
 
         # Parse issues based on section
         if current_section == "missing_imports" &&
-           occursin("is not explicitly imported", line)
+                occursin("is not explicitly imported", line)
             # Extract: "SomeModule.function is not explicitly imported"
             m = match(r"(\w+)\.(\w+) is not explicitly imported", line)
             if m !== nothing
-                push!(issues,
+                push!(
+                    issues,
                     (
                         type = :missing_import,
                         module_name = m.captures[1],
                         symbol = m.captures[2],
-                        line = line
-                    ))
+                        line = line,
+                    )
+                )
             end
         elseif current_section == "unnecessary_imports" &&
-               occursin("is explicitly imported but not used", line)
+                occursin("is explicitly imported but not used", line)
             # Extract: "function is explicitly imported but not used"
             m = match(r"(\w+) is explicitly imported but not used", line)
             if m !== nothing
-                push!(issues, (
-                    type = :unused_import,
-                    symbol = m.captures[1],
-                    line = line
-                ))
+                push!(
+                    issues, (
+                        type = :unused_import,
+                        symbol = m.captures[1],
+                        line = line,
+                    )
+                )
             end
         elseif occursin("FAIL", line) || occursin("WARN", line)
             # Generic issue detection
-            push!(issues, (
-                type = :generic,
-                section = current_section,
-                line = line
-            ))
+            push!(
+                issues, (
+                    type = :generic,
+                    section = current_section,
+                    line = line,
+                )
+            )
         end
     end
 
@@ -341,8 +351,10 @@ function fix_unused_import(file_path::String, symbol::String)
                     continue
                 else
                     # Reconstruct the line
-                    push!(modified_lines, "$(indent)$(keyword) $(module_name): " *
-                                          join(filtered, ", "))
+                    push!(
+                        modified_lines, "$(indent)$(keyword) $(module_name): " *
+                            join(filtered, ", ")
+                    )
                 end
                 # Handle "import Module.symbol" format
             elseif occursin(Regex("^\\s*import\\s+\\w+\\.$(escaped_symbol)\\s*\$"), line)
@@ -487,11 +499,13 @@ end
 
 Clone a repository, fix its explicit imports, and optionally create a PR.
 """
-function fix_repo_explicit_imports(repo_name::String;
+function fix_repo_explicit_imports(
+        repo_name::String;
         work_dir::String = mktempdir(),
         max_iterations::Int = 10,
         create_pr::Bool = true,
-        verbose::Bool = true)
+        verbose::Bool = true
+    )
 
     # Clone repository
     repo_dir = joinpath(work_dir, replace(repo_name, "/" => "_"))
@@ -514,7 +528,7 @@ function fix_repo_explicit_imports(repo_name::String;
 
     # Fix explicit imports
     success, iterations,
-    final_report = fix_explicit_imports(repo_dir; max_iterations, verbose)
+        final_report = fix_explicit_imports(repo_dir; max_iterations, verbose)
 
     if !success
         @warn "Could not fully fix explicit imports for $repo_name"
@@ -610,13 +624,15 @@ end
 
 Fix explicit imports for all Julia packages in a GitHub organization.
 """
-function fix_org_explicit_imports(org_name::String;
+function fix_org_explicit_imports(
+        org_name::String;
         work_dir::String = mktempdir(),
         max_iterations::Int = 10,
         create_prs::Bool = true,
         skip_repos::Vector{String} = String[],
         only_repos::Union{Nothing, Vector{String}} = nothing,
-        verbose::Bool = true)
+        verbose::Bool = true
+    )
     @info "Fetching repositories for organization: $org_name"
 
     # Get repositories
@@ -649,11 +665,13 @@ function fix_org_explicit_imports(org_name::String;
         @info "="^60
 
         try
-            success = fix_repo_explicit_imports(repo;
+            success = fix_repo_explicit_imports(
+                repo;
                 work_dir,
                 max_iterations,
                 create_pr = create_prs,
-                verbose)
+                verbose
+            )
             results[repo] = success
         catch e
             @error "Failed to process $repo: $e"

--- a/src/formatting.jl
+++ b/src/formatting.jl
@@ -34,7 +34,7 @@ function format_repository(
         create_pr::Bool = true,
         fork_user::String = "",
         working_dir::String = mktempdir()
-)
+    )
 
     # Validate inputs
     if create_pr && isempty(fork_user)
@@ -44,14 +44,14 @@ function format_repository(
             @info "Using GitHub username from gh CLI: $fork_user"
         catch
             error_msg = "fork_user must be provided when create_pr=true (or configure gh CLI)"
-            @error error_msg repo=repo_url
+            @error error_msg repo = repo_url
             return (false, error_msg, nothing)
         end
     end
 
     if push_to_master && create_pr
         error_msg = "Cannot both push_to_master and create_pr"
-        @error error_msg repo=repo_url
+        @error error_msg repo = repo_url
         return (false, error_msg, nothing)
     end
 
@@ -70,8 +70,11 @@ function format_repository(
 
         cd(repo_path) do
             # Get default branch
-            default_branch = strip(read(
-                `git symbolic-ref refs/remotes/origin/HEAD`, String))
+            default_branch = strip(
+                read(
+                    `git symbolic-ref refs/remotes/origin/HEAD`, String
+                )
+            )
             default_branch = split(default_branch, "/")[end]
 
             # Create branch if not pushing to master
@@ -98,7 +101,7 @@ function format_repository(
                 JuliaFormatter.format(".")
                 true
             catch e
-                @warn "Formatter encountered errors" exception=e
+                @warn "Formatter encountered errors" exception = e
                 false
             end
 
@@ -108,8 +111,10 @@ function format_repository(
 
             # If only change is the formatter config, no formatting was needed
             if isempty(changed_files) ||
-               (length(changed_files) == 1 && formatter_config_created &&
-                occursin(".JuliaFormatter.toml", changed_files[1]))
+                    (
+                    length(changed_files) == 1 && formatter_config_created &&
+                        occursin(".JuliaFormatter.toml", changed_files[1])
+                )
                 @info "No formatting changes needed"
                 return (true, "No formatting changes needed", nothing)
             end
@@ -126,7 +131,7 @@ function format_repository(
             stats = read(`git diff --cached --stat`, String)
             num_files_changed = count(c -> c == '\n', stats) - 1
 
-            @info "Formatting complete" files_changed=num_files_changed
+            @info "Formatting complete" files_changed = num_files_changed
 
             # Run tests if requested
             test_passed = true
@@ -167,7 +172,7 @@ function format_repository(
                 return (
                     true,
                     "Successfully pushed formatting changes to $default_branch",
-                    nothing
+                    nothing,
                 )
             elseif create_pr
                 @info "Creating pull request..."
@@ -222,7 +227,7 @@ function format_repository(
                     local_sha = strip(read(`git rev-parse HEAD`, String))
 
                     if !isempty(remote_sha) && remote_sha != local_sha
-                        @warn "Push may not have completed successfully" local_sha=local_sha remote_sha=remote_sha
+                        @warn "Push may not have completed successfully" local_sha = local_sha remote_sha = remote_sha
                     end
                 catch e
                     error_msg = "Failed to push to fork: $(sprint(showerror, e))"
@@ -237,7 +242,7 @@ function format_repository(
                 # Check for any uncommitted changes
                 uncommitted = read(`git status --porcelain`, String)
                 if !isempty(uncommitted)
-                    @warn "Uncommitted changes detected" changes=uncommitted
+                    @warn "Uncommitted changes detected" changes = uncommitted
                 end
 
                 # Create PR using gh CLI
@@ -263,14 +268,15 @@ function format_repository(
                 existing_pr = try
                     pr_list = read(
                         `gh pr list --repo $org/$repo --head $fork_user:fix-formatting --json url --jq '.[0].url'`,
-                        String)
+                        String
+                    )
                     strip(pr_list)
                 catch
                     ""
                 end
 
                 if !isempty(existing_pr)
-                    @info "Pull request already exists, will update it" pr=existing_pr
+                    @info "Pull request already exists, will update it" pr = existing_pr
                     rm("pr_body.txt"; force = true)
                     return (true, "Updated existing pull request", existing_pr)
                 end
@@ -291,9 +297,11 @@ function format_repository(
                         catch e
                             error_str = sprint(showerror, e)
                             if attempt < 3 &&
-                               (occursin("No commits between", error_str) ||
-                                occursin("Head sha can't be blank", error_str))
-                                @warn "GitHub hasn't processed the push yet, retrying..." attempt=attempt error=error_str
+                                    (
+                                    occursin("No commits between", error_str) ||
+                                        occursin("Head sha can't be blank", error_str)
+                                )
+                                @warn "GitHub hasn't processed the push yet, retrying..." attempt = attempt error = error_str
                                 sleep(5)  # Increased retry delay
                             else
                                 # Re-throw on last attempt or different error
@@ -319,14 +327,15 @@ function format_repository(
                         existing_pr = try
                             pr_list = read(
                                 `gh pr list --repo $org/$repo --head $fork_user:fix-formatting --json url --jq '.[0].url'`,
-                                String)
+                                String
+                            )
                             strip(pr_list)
                         catch
                             ""
                         end
 
                         if !isempty(existing_pr)
-                            @info "Pull request already exists (from error), updated it" pr=existing_pr
+                            @info "Pull request already exists (from error), updated it" pr = existing_pr
                             return (true, "Updated existing pull request", existing_pr)
                         end
                     end
@@ -364,7 +373,8 @@ function run_tests(repo_path::String; timeout_minutes::Int = 10)
         # Run tests with timeout
         test_cmd = `julia --project=. -e "using Pkg; Pkg.test()"`
         test_process = run(
-            pipeline(test_cmd; stdout = stdout, stderr = stderr); wait = false)
+            pipeline(test_cmd; stdout = stdout, stderr = stderr); wait = false
+        )
 
         # Wait for tests with timeout
         test_start = time()
@@ -387,7 +397,7 @@ function run_tests(repo_path::String; timeout_minutes::Int = 10)
             return false
         end
     catch e
-        @error "Error running tests" exception=e
+        @error "Error running tests" exception = e
         return false
     end
 end
@@ -428,7 +438,7 @@ function format_org_repositories(
         limit::Int = 100,
         only_failing_ci::Bool = true,
         log_file::String = ""
-)
+    )
 
     # Validate inputs early
     if create_pr && isempty(fork_user)
@@ -459,7 +469,7 @@ function format_org_repositories(
         )
     end
 
-    @info "Starting organization-wide formatting" org=org log_file=log_file
+    @info "Starting organization-wide formatting" org = org log_file = log_file
 
     # Get repositories
     @info "Fetching repositories from $org..."
@@ -488,13 +498,13 @@ function format_org_repositories(
         println(log_io)
 
         for (i, repo) in enumerate(repos)
-            @info "Processing repository" repo=repo progress="$i/$(length(repos))"
+            @info "Processing repository" repo = repo progress = "$i/$(length(repos))"
             println(log_io, "\n[$i/$(length(repos))] Processing $repo...")
 
             repo_url = "https://github.com/$org/$repo.git"
 
             success, message,
-            pr_url = format_repository(
+                pr_url = format_repository(
                 repo_url;
                 test = test,
                 push_to_master = push_to_master,
@@ -507,7 +517,7 @@ function format_org_repositories(
                 push!(successes, repo)
                 if pr_url !== nothing
                     push!(pr_urls, pr_url)
-                    @info "✓ SUCCESS: $repo - $message" pr=pr_url
+                    @info "✓ SUCCESS: $repo - $message" pr = pr_url
                     println(log_io, "✓ SUCCESS: $message")
                     println(log_io, "  PR: $pr_url")
                 else
@@ -545,9 +555,9 @@ function format_org_repositories(
 
     rm(working_dir; force = true, recursive = true)
 
-    @info "Organization formatting complete" successes=length(successes) failures=length(
+    @info "Organization formatting complete" successes = length(successes) failures = length(
         failures,
-    ) prs=length(pr_urls)
+    ) prs = length(pr_urls)
 
     return (successes, failures, pr_urls)
 end
@@ -564,7 +574,7 @@ function get_org_repositories(org::String, limit::Int = 100)
         repos = filter(!isempty, split(strip(output), '\n'))
         return String.(repos)  # Convert to Vector{String}
     catch e
-        @error "Failed to fetch repositories" exception=e
+        @error "Failed to fetch repositories" exception = e
         return String[]
     end
 end
@@ -588,9 +598,9 @@ function has_failing_formatter_ci(org::String, repo::String)
                 if !isempty(output)
                     # Check if any run on the target branch has failed
                     if occursin("\"headBranch\":\"$branch\"", output) && (
-                        occursin("\"conclusion\":\"failure\"", output) ||
-                        occursin("\"status\":\"failure\"", output)
-                    )
+                            occursin("\"conclusion\":\"failure\"", output) ||
+                                occursin("\"status\":\"failure\"", output)
+                        )
                         return true
                     end
                 end

--- a/src/import_timing_analysis.jl
+++ b/src/import_timing_analysis.jl
@@ -58,66 +58,68 @@ function analyze_import_timing_in_process(repo_path::String, package_name::Strin
     # Create a temporary script to capture structured timing data
     analysis_script = joinpath(tempdir(), "import_timing_$(randstring(8)).jl")
 
-    write(analysis_script, """
-        using Pkg
-        using JSON3
-        
-        # Activate and instantiate the project
-        Pkg.activate(".")
-        Pkg.instantiate()
-        
-        # Capture timing data in a structured way
-        timing_data = []
-        raw_output = IOBuffer()
-        
-        # Redirect stdout to capture the timing output
-        original_stdout = stdout
-        redirect_stdout(raw_output) do
-            # Run with time imports flag
-            Base.eval(Main, :(using InteractiveUtils))
-            Base.eval(Main, :(@time_imports using \$(Symbol("$package_name"))))
-        end
-        
-        # Process the captured output
-        raw_str = String(take!(raw_output))
-        lines = split(raw_str, '\n')
-        
-        for line in lines
-            line = strip(line)
-            if isempty(line) || !contains(line, "ms")
-                continue
+    write(
+        analysis_script, """
+            using Pkg
+            using JSON3
+            
+            # Activate and instantiate the project
+            Pkg.activate(".")
+            Pkg.instantiate()
+            
+            # Capture timing data in a structured way
+            timing_data = []
+            raw_output = IOBuffer()
+            
+            # Redirect stdout to capture the timing output
+            original_stdout = stdout
+            redirect_stdout(raw_output) do
+                # Run with time imports flag
+                Base.eval(Main, :(using InteractiveUtils))
+                Base.eval(Main, :(@time_imports using \$(Symbol("$package_name"))))
             end
             
-            # Parse timing line format
-            timing_match = match(r"^\\s*(\\d+\\.?\\d*)\\s*ms\\s*([✓]?)\\s*(.+)\$", line)
-            if timing_match !== nothing
-                time_ms = parse(Float64, timing_match.captures[1])
-                success_marker = timing_match.captures[2]
-                pkg_name = strip(timing_match.captures[3])
+            # Process the captured output
+            raw_str = String(take!(raw_output))
+            lines = split(raw_str, '\n')
+            
+            for line in lines
+                line = strip(line)
+                if isempty(line) || !contains(line, "ms")
+                    continue
+                end
                 
-                push!(timing_data, Dict(
-                    "package" => pkg_name,
-                    "time_ms" => time_ms,
-                    "time_seconds" => time_ms / 1000.0,
-                    "is_precompile" => isempty(success_marker),
-                    "is_local" => (pkg_name == "$package_name"),
-                    "line" => line
-                ))
+                # Parse timing line format
+                timing_match = match(r"^\\s*(\\d+\\.?\\d*)\\s*ms\\s*([✓]?)\\s*(.+)\$", line)
+                if timing_match !== nothing
+                    time_ms = parse(Float64, timing_match.captures[1])
+                    success_marker = timing_match.captures[2]
+                    pkg_name = strip(timing_match.captures[3])
+                    
+                    push!(timing_data, Dict(
+                        "package" => pkg_name,
+                        "time_ms" => time_ms,
+                        "time_seconds" => time_ms / 1000.0,
+                        "is_precompile" => isempty(success_marker),
+                        "is_local" => (pkg_name == "$package_name"),
+                        "line" => line
+                    ))
+                end
             end
-        end
-        
-        # Output JSON directly
-        results = Dict(
-            "package_name" => "$package_name",
-            "timing_entries" => timing_data,
-            "raw_output" => raw_str,
-            "total_entries" => length(timing_data)
-        )
-        
-        println("===JSON_START===")
-        JSON3.pretty(stdout, results)
-        println("\n===JSON_END===")
-    """)
+            
+            # Output JSON directly
+            results = Dict(
+                "package_name" => "$package_name",
+                "timing_entries" => timing_data,
+                "raw_output" => raw_str,
+                "total_entries" => length(timing_data)
+            )
+            
+            println("===JSON_START===")
+            JSON3.pretty(stdout, results)
+            println("\n===JSON_END===")
+        """
+    )
 
     # Run the analysis script
     @info "Running import timing analysis in separate process..."
@@ -175,7 +177,8 @@ function analyze_import_timing_fallback(output::String, package_name::String)
             success_marker = timing_match.captures[2]
             pkg_name = strip(timing_match.captures[3])
 
-            push!(timing_data,
+            push!(
+                timing_data,
                 Dict(
                     "package" => pkg_name,
                     "time_ms" => time_ms,
@@ -183,7 +186,8 @@ function analyze_import_timing_fallback(output::String, package_name::String)
                     "is_precompile" => isempty(success_marker),
                     "is_local" => (pkg_name == package_name),
                     "line" => line
-                ))
+                )
+            )
         end
     end
 
@@ -235,7 +239,8 @@ function parse_import_timings(timing_data::Dict)
     import_timings = ImportTiming[]
 
     for (pkg_name, timing_info) in package_timings
-        push!(import_timings,
+        push!(
+            import_timings,
             ImportTiming(
                 pkg_name,
                 timing_info["total_time"],
@@ -244,7 +249,8 @@ function parse_import_timings(timing_data::Dict)
                 timing_info["dependencies"],  # TODO: Could be enhanced to detect actual deps
                 0,  # TODO: Could count dependencies
                 timing_info["is_local"]
-            ))
+            )
+        )
     end
 
     # Sort by total time (descending)
@@ -287,13 +293,13 @@ function generate_import_timing_report(repo_path::String, package_name::String =
 
         # Generate summary
         summary = if total_time < 1.0
-            "✅ Fast import ($(round(total_time, digits=2))s) - excellent performance"
+            "✅ Fast import ($(round(total_time, digits = 2))s) - excellent performance"
         elseif total_time < 3.0
-            "✅ Good import time ($(round(total_time, digits=2))s) - acceptable performance"
+            "✅ Good import time ($(round(total_time, digits = 2))s) - acceptable performance"
         elseif total_time < 10.0
-            "⚠️  Moderate import time ($(round(total_time, digits=2))s) - room for improvement"
+            "⚠️  Moderate import time ($(round(total_time, digits = 2))s) - room for improvement"
         else
-            "❌ Slow import time ($(round(total_time, digits=2))s) - significant impact on user experience"
+            "❌ Slow import time ($(round(total_time, digits = 2))s) - significant impact on user experience"
         end
 
         # Generate recommendations
@@ -304,21 +310,27 @@ function generate_import_timing_report(repo_path::String, package_name::String =
             slow_deps = filter(t -> !t.is_local && t.total_time > 0.5, import_timings)
             if !isempty(slow_deps)
                 slowest = slow_deps[1]
-                push!(recommendations,
-                    "Consider reducing dependency on '$(slowest.package_name)' ($(round(slowest.total_time, digits=2))s)")
+                push!(
+                    recommendations,
+                    "Consider reducing dependency on '$(slowest.package_name)' ($(round(slowest.total_time, digits = 2))s)"
+                )
             end
 
             # Precompilation recommendations
             high_precompile = filter(t -> t.precompile_time > 1.0, import_timings)
             if !isempty(high_precompile)
-                push!(recommendations,
-                    "High precompilation times detected - consider using PackageCompiler.jl for system images")
+                push!(
+                    recommendations,
+                    "High precompilation times detected - consider using PackageCompiler.jl for system images"
+                )
             end
 
             # General recommendations
             if length(import_timings) > 10
-                push!(recommendations,
-                    "Large number of dependencies ($(length(import_timings))) - consider reducing if possible")
+                push!(
+                    recommendations,
+                    "Large number of dependencies ($(length(import_timings))) - consider reducing if possible"
+                )
             end
 
             if total_time > 5.0
@@ -344,8 +356,9 @@ function generate_import_timing_report(repo_path::String, package_name::String =
         )
 
     catch e
-        @error "Failed to analyze import timing for $repo_path" exception=(
-            e, catch_backtrace())
+        @error "Failed to analyze import timing for $repo_path" exception = (
+            e, catch_backtrace(),
+        )
         return ImportTimingReport(
             basename(repo_path),
             package_name,
@@ -376,16 +389,16 @@ function analyze_repo_import_timing(repo_path::String; package_name::String = ""
     println("Analysis Time: $(report.analysis_time)")
     println("="^60)
     println(report.summary)
-    println("\\nTotal Import Time: $(round(report.total_import_time, digits=2)) seconds")
+    println("\\nTotal Import Time: $(round(report.total_import_time, digits = 2)) seconds")
 
     if report.total_import_time > 0
         println("\\nMajor Contributors:")
         for (i, timing) in enumerate(report.major_contributors)
             local_marker = timing.is_local ? " (LOCAL)" : ""
             println("  $i. $(timing.package_name)$local_marker")
-            println("     Total: $(round(timing.total_time, digits=2))s")
+            println("     Total: $(round(timing.total_time, digits = 2))s")
             if timing.precompile_time > 0.01
-                println("     Precompile: $(round(timing.precompile_time, digits=2))s, Load: $(round(timing.load_time, digits=2))s")
+                println("     Precompile: $(round(timing.precompile_time, digits = 2))s, Load: $(round(timing.load_time, digits = 2))s")
             end
             println()
         end
@@ -422,11 +435,13 @@ end
 
 Analyze import timing across all repositories in a GitHub organization.
 """
-function analyze_org_import_timing(org::String;
+function analyze_org_import_timing(
+        org::String;
         auth_token::String = "",
         work_dir::String = mktempdir(),
         output_dir::String = "",
-        max_repos::Int = 0)
+        max_repos::Int = 0
+    )
     @info "Analyzing import timing for organization: $org"
 
     # Get all repositories
@@ -473,7 +488,7 @@ function analyze_org_import_timing(org::String;
             end
 
         catch e
-            @error "Failed to process $repo_name" exception=(e, catch_backtrace())
+            @error "Failed to process $repo_name" exception = (e, catch_backtrace())
             results[repo_name] = ImportTimingReport(
                 repo_name,
                 "",
@@ -512,18 +527,20 @@ function write_import_timing_report(report::ImportTimingReport, output_file::Str
         "dependency_chain" => report.dependency_chain,
         "recommendations" => report.recommendations,
         "raw_output" => report.raw_output,
-        "major_contributors" => [Dict(
-                                     "package_name" => timing.package_name,
-                                     "total_time" => timing.total_time,
-                                     "precompile_time" => timing.precompile_time,
-                                     "load_time" => timing.load_time,
-                                     "dependencies" => timing.dependencies,
-                                     "dep_count" => timing.dep_count,
-                                     "is_local" => timing.is_local
-                                 ) for timing in report.major_contributors]
+        "major_contributors" => [
+            Dict(
+                    "package_name" => timing.package_name,
+                    "total_time" => timing.total_time,
+                    "precompile_time" => timing.precompile_time,
+                    "load_time" => timing.load_time,
+                    "dependencies" => timing.dependencies,
+                    "dep_count" => timing.dep_count,
+                    "is_local" => timing.is_local
+                ) for timing in report.major_contributors
+        ]
     )
 
-    open(output_file, "w") do io
+    return open(output_file, "w") do io
         JSON3.pretty(io, report_data)
     end
 end
@@ -534,7 +551,8 @@ end
 Generate a summary report for import timing across the entire organization.
 """
 function generate_org_import_summary_report(
-        org::String, results::Dict{String, ImportTimingReport}, output_dir::String)
+        org::String, results::Dict{String, ImportTimingReport}, output_dir::String
+    )
     if isempty(output_dir)
         output_dir = tempdir()
     end
@@ -550,9 +568,12 @@ function generate_org_import_summary_report(
 
     # Find slowest repositories
     slowest_repos = sort(
-        [(name, report.total_import_time)
-         for (name, report) in results if report.total_import_time > 0],
-        by = x -> x[2], rev = true)
+        [
+            (name, report.total_import_time)
+                for (name, report) in results if report.total_import_time > 0
+        ],
+        by = x -> x[2], rev = true
+    )
 
     # Aggregate slow dependencies across organization
     all_dependencies = Dict{String, Vector{Float64}}()
@@ -568,8 +589,10 @@ function generate_org_import_summary_report(
     end
 
     # Calculate average time per dependency across all repos
-    dependency_stats = [(dep, mean(times), length(times))
-                        for (dep, times) in all_dependencies]
+    dependency_stats = [
+        (dep, mean(times), length(times))
+            for (dep, times) in all_dependencies
+    ]
     sort!(dependency_stats, by = x -> x[2], rev = true)  # Sort by average time
 
     # Generate markdown report
@@ -583,8 +606,8 @@ function generate_org_import_summary_report(
         println(io, "- **Total Repositories Analyzed**: $total_repos")
         println(io, "- **Successful Analyses**: $successful_analyses")
         println(io, "- **Failed Analyses**: $failed_analyses")
-        println(io, "- **Average Import Time**: $(round(avg_import_time, digits=2)) seconds")
-        println(io, "- **Total Import Time Across Org**: $(round(total_import_time, digits=2)) seconds")
+        println(io, "- **Average Import Time**: $(round(avg_import_time, digits = 2)) seconds")
+        println(io, "- **Total Import Time Across Org**: $(round(total_import_time, digits = 2)) seconds")
         println(io)
 
         if !isempty(slowest_repos)
@@ -597,7 +620,7 @@ function generate_org_import_summary_report(
                 else
                     "❌"
                 end
-                println(io, "$i. $status **$repo**: $(round(time, digits=2))s")
+                println(io, "$i. $status **$repo**: $(round(time, digits = 2))s")
             end
             println(io)
         end
@@ -609,7 +632,7 @@ function generate_org_import_summary_report(
             for (i, (dep, avg_time, repo_count)) in
                 enumerate(dependency_stats[1:min(10, end)])
                 println(io, "$i. **$dep**")
-                println(io, "   - Average impact: $(round(avg_time, digits=2))s")
+                println(io, "   - Average impact: $(round(avg_time, digits = 2))s")
                 println(io, "   - Affects $repo_count repositories")
                 println(io)
             end
@@ -620,13 +643,17 @@ function generate_org_import_summary_report(
         if avg_import_time < 1.0
             println(io, "🎉 Excellent! Average import times are very good across the organization.")
         elseif avg_import_time < 3.0
-            println(io,
-                "✅ Good import performance overall. Focus on the slowest packages for improvements.")
+            println(
+                io,
+                "✅ Good import performance overall. Focus on the slowest packages for improvements."
+            )
         elseif avg_import_time < 8.0
             println(io, "⚠️ Moderate import times. Consider organization-wide optimization initiatives.")
         else
-            println(io,
-                "❌ Slow import times detected. Immediate attention recommended for user experience.")
+            println(
+                io,
+                "❌ Slow import times detected. Immediate attention recommended for user experience."
+            )
         end
 
         println(io)
@@ -635,8 +662,10 @@ function generate_org_import_summary_report(
 
         if !isempty(dependency_stats)
             worst_dep = dependency_stats[1][1]
-            println(io,
-                "2. **Dependency Review**: Investigate organization's usage of '$worst_dep' and similar slow dependencies")
+            println(
+                io,
+                "2. **Dependency Review**: Investigate organization's usage of '$worst_dep' and similar slow dependencies"
+            )
         end
 
         println(io, "3. **Best Practices**: Share optimization techniques from fast-loading packages")
@@ -651,13 +680,15 @@ function generate_org_import_summary_report(
             status = report.total_import_time >= 0 ? "✅ Success" : "❌ Failed"
             println(io, "- **Status**: $status")
             if report.total_import_time >= 0
-                println(io, "- **Import Time**: $(round(report.total_import_time, digits=2))s")
+                println(io, "- **Import Time**: $(round(report.total_import_time, digits = 2))s")
                 println(io, "- **Package**: $(report.package_name)")
                 if !isempty(report.major_contributors)
                     slowest_dep = report.major_contributors[1]
                     if !slowest_dep.is_local
-                        println(io,
-                            "- **Slowest Dependency**: $(slowest_dep.package_name) ($(round(slowest_dep.total_time, digits=2))s)")
+                        println(
+                            io,
+                            "- **Slowest Dependency**: $(slowest_dep.package_name) ($(round(slowest_dep.total_time, digits = 2))s)"
+                        )
                     end
                 end
             end

--- a/src/invalidation_analysis.jl
+++ b/src/invalidation_analysis.jl
@@ -70,88 +70,89 @@ function analyze_invalidations_in_process(repo_path::String, test_script::String
 
     write(
         analysis_script, """
-      using SnoopCompileCore
-      import SnoopCompileCore: InferenceTimingNode, InfTiming
-      
-      # Change to repository directory
-      cd("$repo_path")
-      
-      println("Starting invalidation analysis for: $repo_path")
-      
-      # Start monitoring invalidations
-      invalidations = @snoopr begin
-          $test_code
-      end
-      
-      println("Captured \$(length(invalidations)) invalidations")
-      
-      # Analyze invalidation tree
-      trees = invalidation_trees(invalidations)
-      
-      # Extract detailed information about each invalidation
-      invalidation_data = []
-      
-      function extract_invalidation_info(node, depth=0)
-          for child in node.children
-              method_info = string(child.method)
-              
-              # Extract file and line information if available
-              file = "unknown"
-              line = 0
-              package = "unknown"
-              
-              try
-                  if hasfield(typeof(child.method), :file) && hasfield(typeof(child.method), :line)
-                      file = string(child.method.file)
-                      line = child.method.line
-                      
-                      # Try to determine package from file path
-                      if contains(file, ".julia/packages/")
-                          pkg_match = match(r"\\.julia/packages/([^/]+)", file)
-                          if pkg_match !== nothing
-                              package = pkg_match.captures[1]
-                          end
-                      elseif contains(file, "src/")
-                          # Local package
-                          package = "local"
-                      end
-                  end
-              catch e
-                  # Fallback if we can't extract file info
-              end
-              
-              children_count = length(child.children)
-              
-              push!(invalidation_data, Dict(
-                  "method" => method_info,
-                  "file" => file,
-                  "line" => line,
-                  "package" => package,
-                  "children_count" => children_count,
-                  "depth" => depth
-              ))
-              
-              # Recursively process children
-              extract_invalidation_info(child, depth + 1)
-          end
-      end
-      
-      for tree in trees
-          extract_invalidation_info(tree)
-      end
-      
-      # Save results as JSON
-      results = Dict(
-          "total_invalidations" => length(invalidations),
-          "tree_count" => length(trees),
-          "invalidation_details" => invalidation_data
-      )
-      
-      # Output JSON directly to stdout for the main process to capture
-      println("===JSON_START===")
-      JSON3.pretty(stdout, results)
-      println("\n===JSON_END===")
-  """)
+            using SnoopCompileCore
+            import SnoopCompileCore: InferenceTimingNode, InfTiming
+            
+            # Change to repository directory
+            cd("$repo_path")
+            
+            println("Starting invalidation analysis for: $repo_path")
+            
+            # Start monitoring invalidations
+            invalidations = @snoopr begin
+                $test_code
+            end
+            
+            println("Captured \$(length(invalidations)) invalidations")
+            
+            # Analyze invalidation tree
+            trees = invalidation_trees(invalidations)
+            
+            # Extract detailed information about each invalidation
+            invalidation_data = []
+            
+            function extract_invalidation_info(node, depth=0)
+                for child in node.children
+                    method_info = string(child.method)
+                    
+                    # Extract file and line information if available
+                    file = "unknown"
+                    line = 0
+                    package = "unknown"
+                    
+                    try
+                        if hasfield(typeof(child.method), :file) && hasfield(typeof(child.method), :line)
+                            file = string(child.method.file)
+                            line = child.method.line
+                            
+                            # Try to determine package from file path
+                            if contains(file, ".julia/packages/")
+                                pkg_match = match(r"\\.julia/packages/([^/]+)", file)
+                                if pkg_match !== nothing
+                                    package = pkg_match.captures[1]
+                                end
+                            elseif contains(file, "src/")
+                                # Local package
+                                package = "local"
+                            end
+                        end
+                    catch e
+                        # Fallback if we can't extract file info
+                    end
+                    
+                    children_count = length(child.children)
+                    
+                    push!(invalidation_data, Dict(
+                        "method" => method_info,
+                        "file" => file,
+                        "line" => line,
+                        "package" => package,
+                        "children_count" => children_count,
+                        "depth" => depth
+                    ))
+                    
+                    # Recursively process children
+                    extract_invalidation_info(child, depth + 1)
+                end
+            end
+            
+            for tree in trees
+                extract_invalidation_info(tree)
+            end
+            
+            # Save results as JSON
+            results = Dict(
+                "total_invalidations" => length(invalidations),
+                "tree_count" => length(trees),
+                "invalidation_details" => invalidation_data
+            )
+            
+            # Output JSON directly to stdout for the main process to capture
+            println("===JSON_START===")
+            JSON3.pretty(stdout, results)
+            println("\n===JSON_END===")
+        """
+    )
 
     # Run the analysis in a separate process
     try
@@ -218,13 +219,16 @@ function analyze_major_invalidators(invalidation_data::AbstractDict)
     end
 
     # Convert to vector and sort by impact
-    package_impact = [(pkg, stats["total_children"], stats["count"])
-                      for (pkg, stats) in package_stats]
+    package_impact = [
+        (pkg, stats["total_children"], stats["count"])
+            for (pkg, stats) in package_stats
+    ]
     sort!(package_impact, by = x -> x[2], rev = true)
 
     major_invalidators = []
     for inv in sorted_by_impact[1:min(20, end)]  # Top 20 invalidators
-        push!(major_invalidators,
+        push!(
+            major_invalidators,
             InvalidationEntry(
                 inv["method"],
                 inv["file"],
@@ -233,7 +237,8 @@ function analyze_major_invalidators(invalidation_data::AbstractDict)
                 "High-impact invalidation ($(inv["children_count"]) children)",
                 inv["children_count"],
                 inv["depth"]
-            ))
+            )
+        )
     end
 
     return major_invalidators, package_impact
@@ -279,28 +284,38 @@ function generate_invalidation_report(repo_path::String, test_script::String = "
             if length(package_impact) > 0
                 top_pkg, top_impact, top_count = package_impact[1]
                 if top_impact > 10
-                    push!(recommendations,
-                        "Focus on package '$top_pkg' - it causes $top_impact invalidations ($top_count instances)")
+                    push!(
+                        recommendations,
+                        "Focus on package '$top_pkg' - it causes $top_impact invalidations ($top_count instances)"
+                    )
                 end
             end
 
             # Type stability recommendations
             if any(inv -> inv.children_count > 5, major_invalidators)
-                push!(recommendations,
-                    "Consider improving type stability in methods with high invalidation counts")
+                push!(
+                    recommendations,
+                    "Consider improving type stability in methods with high invalidation counts"
+                )
             end
 
             # Dependency recommendations
             if length(packages_affected) > 5
-                push!(recommendations,
-                    "Review dependencies - $(length(packages_affected)) packages are involved in invalidations")
+                push!(
+                    recommendations,
+                    "Review dependencies - $(length(packages_affected)) packages are involved in invalidations"
+                )
             end
 
             # General recommendations
-            push!(recommendations,
-                "Run `@time_imports using YourPackage` to identify slow-loading dependencies")
-            push!(recommendations,
-                "Consider using `@nospecialize` for arguments that don't need to be specialized")
+            push!(
+                recommendations,
+                "Run `@time_imports using YourPackage` to identify slow-loading dependencies"
+            )
+            push!(
+                recommendations,
+                "Consider using `@nospecialize` for arguments that don't need to be specialized"
+            )
             push!(recommendations, "Profile with `@profile` to identify performance bottlenecks")
         else
             push!(recommendations, "Great job! No invalidations detected. Your package is well-optimized.")
@@ -317,8 +332,9 @@ function generate_invalidation_report(repo_path::String, test_script::String = "
         )
 
     catch e
-        @error "Failed to analyze invalidations for $repo_path" exception=(
-            e, catch_backtrace())
+        @error "Failed to analyze invalidations for $repo_path" exception = (
+            e, catch_backtrace(),
+        )
         return InvalidationReport(
             basename(repo_path),
             -1,  # Indicates error
@@ -387,12 +403,14 @@ end
 
 Analyze invalidations across all repositories in a GitHub organization.
 """
-function analyze_org_invalidations(org::String;
+function analyze_org_invalidations(
+        org::String;
         auth_token::String = "",
         work_dir::String = mktempdir(),
         test_script::String = "",
         output_dir::String = "",
-        max_repos::Int = 0)
+        max_repos::Int = 0
+    )
     @info "Analyzing invalidations for organization: $org"
 
     # Get all repositories
@@ -439,7 +457,7 @@ function analyze_org_invalidations(org::String;
             end
 
         catch e
-            @error "Failed to process $repo_name" exception=(e, catch_backtrace())
+            @error "Failed to process $repo_name" exception = (e, catch_backtrace())
             results[repo_name] = InvalidationReport(
                 repo_name,
                 -1,
@@ -474,18 +492,20 @@ function write_invalidation_report(report::InvalidationReport, output_file::Stri
         "summary" => report.summary,
         "packages_affected" => report.packages_affected,
         "recommendations" => report.recommendations,
-        "major_invalidators" => [Dict(
-                                     "method" => inv.method,
-                                     "file" => inv.file,
-                                     "line" => inv.line,
-                                     "package" => inv.package,
-                                     "reason" => inv.reason,
-                                     "children_count" => inv.children_count,
-                                     "depth" => inv.depth
-                                 ) for inv in report.major_invalidators]
+        "major_invalidators" => [
+            Dict(
+                    "method" => inv.method,
+                    "file" => inv.file,
+                    "line" => inv.line,
+                    "package" => inv.package,
+                    "reason" => inv.reason,
+                    "children_count" => inv.children_count,
+                    "depth" => inv.depth
+                ) for inv in report.major_invalidators
+        ]
     )
 
-    open(output_file, "w") do io
+    return open(output_file, "w") do io
         JSON3.pretty(io, report_data)
     end
 end
@@ -505,16 +525,21 @@ function generate_org_summary_report(org::String, results::Dict{String, Invalida
     successful_analyses = count(r -> r.total_invalidations >= 0, values(results))
     failed_analyses = total_repos - successful_analyses
 
-    total_invalidations = sum(r.total_invalidations
-    for r in values(results) if r.total_invalidations >= 0)
+    total_invalidations = sum(
+        r.total_invalidations
+            for r in values(results) if r.total_invalidations >= 0
+    )
     avg_invalidations = successful_analyses > 0 ?
-                        total_invalidations / successful_analyses : 0
+        total_invalidations / successful_analyses : 0
 
     # Find worst repositories
     worst_repos = sort(
-        [(name, report.total_invalidations)
-         for (name, report) in results if report.total_invalidations > 0],
-        by = x -> x[2], rev = true)
+        [
+            (name, report.total_invalidations)
+                for (name, report) in results if report.total_invalidations > 0
+        ],
+        by = x -> x[2], rev = true
+    )
 
     # Aggregate package problems
     all_packages = Set{String}()
@@ -536,7 +561,7 @@ function generate_org_summary_report(org::String, results::Dict{String, Invalida
         println(io, "- **Successful Analyses**: $successful_analyses")
         println(io, "- **Failed Analyses**: $failed_analyses")
         println(io, "- **Total Invalidations Found**: $total_invalidations")
-        println(io, "- **Average Invalidations per Repo**: $(round(avg_invalidations, digits=1))")
+        println(io, "- **Average Invalidations per Repo**: $(round(avg_invalidations, digits = 1))")
         println(io, "- **Unique Packages Involved**: $(length(all_packages))")
         println(io)
 
@@ -553,11 +578,15 @@ function generate_org_summary_report(org::String, results::Dict{String, Invalida
         if total_invalidations == 0
             println(io, "🎉 Excellent! No invalidations detected across the organization.")
         elseif avg_invalidations < 5
-            println(io,
-                "✅ Good performance overall. Focus on the worst repositories for further improvements.")
+            println(
+                io,
+                "✅ Good performance overall. Focus on the worst repositories for further improvements."
+            )
         elseif avg_invalidations < 20
-            println(io,
-                "⚠️ Moderate invalidation levels. Consider organization-wide performance initiatives.")
+            println(
+                io,
+                "⚠️ Moderate invalidation levels. Consider organization-wide performance initiatives."
+            )
         else
             println(io, "❌ High invalidation levels detected. Immediate attention recommended.")
         end

--- a/src/min_version_fixer.jl
+++ b/src/min_version_fixer.jl
@@ -46,8 +46,10 @@ Downgrade all dependencies to their minimum compatible versions using Resolver.j
 This uses the same approach as julia-actions/julia-downgrade-compat.
 Returns (success::Bool, output::String)
 """
-function downgrade_to_minimum_versions(project_dir::String; julia_version = "1.10",
-        mode = "alldeps", work_dir = mktempdir())
+function downgrade_to_minimum_versions(
+        project_dir::String; julia_version = "1.10",
+        mode = "alldeps", work_dir = mktempdir()
+    )
     project_file = joinpath(project_dir, "Project.toml")
     if !isfile(project_file)
         # Also check for JuliaProject.toml
@@ -96,11 +98,12 @@ Test if minimum versions can be resolved using Resolver.jl.
 Returns (success::Bool, error_output::String)
 """
 function test_min_versions(
-        project_dir::String; julia_version = "1.10", mode = "alldeps", work_dir = mktempdir())
+        project_dir::String; julia_version = "1.10", mode = "alldeps", work_dir = mktempdir()
+    )
     @info "Testing minimum versions for $project_dir with Julia $julia_version and mode $mode"
 
     success,
-    output = downgrade_to_minimum_versions(project_dir; julia_version, mode, work_dir)
+        output = downgrade_to_minimum_versions(project_dir; julia_version, mode, work_dir)
 
     if success
         @info "✓ Successfully resolved minimum versions"
@@ -130,7 +133,7 @@ function parse_resolution_errors(output::String, project_toml::Dict)
         r"restricted by compatibility requirements with (\w+)",
         r"package (\w+) has no versions",
         r"Cannot resolve package (\w+)",
-        r"Unsatisfiable requirements for (\w+)"
+        r"Unsatisfiable requirements for (\w+)",
     ]
 
     # Look for specific error patterns
@@ -147,7 +150,7 @@ function parse_resolution_errors(output::String, project_toml::Dict)
     # Also look for simple package mentions in error lines
     for line in split(output, '\n')
         if occursin("ERROR", line) || occursin("WARN", line) ||
-           occursin("unsatisfiable", lowercase(line))
+                occursin("unsatisfiable", lowercase(line))
             for (pkg_name, _) in deps
                 if occursin(pkg_name, line)
                     @info "Found problematic package in error line: $pkg_name"
@@ -203,7 +206,7 @@ function is_outdated_compat(compat_str::String, pkg_name::String)
     if min_version.major < latest_version.major
         return true  # Major version behind
     elseif min_version.major == latest_version.major &&
-           min_version.minor < latest_version.minor
+            min_version.minor < latest_version.minor
         # For 0.x packages, being behind on minor is significant
         if min_version.major == 0
             return true
@@ -401,6 +404,7 @@ function update_compat!(project_toml::Dict, updates::Dict{String, String})
 
         @info "Updated $pkg: $current → $(compat[pkg])"
     end
+    return
 end
 
 """
@@ -414,11 +418,13 @@ Fix minimum versions for all Project.toml files in a repository.
 Supports repositories with subpackages in the /lib directory.
 Returns (success::Bool, all_updates::Dict{String,Dict{String,String}})
 """
-function fix_package_min_versions_all(repo_path::String;
+function fix_package_min_versions_all(
+        repo_path::String;
         max_iterations::Int = 10,
         work_dir::String = mktempdir(),
         julia_version::String = "1.10",
-        include_subpackages::Bool = true)
+        include_subpackages::Bool = true
+    )
 
     # Find all Project.toml files
     project_files = find_all_project_tomls(repo_path)
@@ -444,10 +450,12 @@ function fix_package_min_versions_all(repo_path::String;
 
         # Fix minimum versions for this project
         success,
-        updates = fix_package_min_versions(project_dir;
+            updates = fix_package_min_versions(
+            project_dir;
             max_iterations,
             work_dir,
-            julia_version)
+            julia_version
+        )
 
         if !isempty(updates)
             all_updates[rel_path] = updates
@@ -470,10 +478,12 @@ end
 Fix minimum versions for a package repository that's already cloned.
 Returns (success::Bool, updates::Dict{String,String})
 """
-function fix_package_min_versions(repo_path::String;
+function fix_package_min_versions(
+        repo_path::String;
         max_iterations::Int = 10,
         work_dir::String = mktempdir(),
-        julia_version::String = "1.10")
+        julia_version::String = "1.10"
+    )
     project_file = joinpath(repo_path, "Project.toml")
 
     if !isfile(project_file)
@@ -562,12 +572,14 @@ end
 Clone a repository, fix its minimum versions, and optionally create a PR.
 Now supports repositories with subpackages in /lib directories.
 """
-function fix_repo_min_versions(repo_name::String;
+function fix_repo_min_versions(
+        repo_name::String;
         work_dir::String = mktempdir(),
         max_iterations::Int = 10,
         create_pr::Bool = true,
         julia_version::String = "1.10",
-        include_subpackages::Bool = true)
+        include_subpackages::Bool = true
+    )
 
     # Clone repository
     repo_dir = joinpath(work_dir, replace(repo_name, "/" => "_"))
@@ -596,11 +608,13 @@ function fix_repo_min_versions(repo_name::String;
     if use_multi
         # Fix minimum versions for all projects
         success,
-        all_updates = fix_package_min_versions_all(repo_dir;
+            all_updates = fix_package_min_versions_all(
+            repo_dir;
             max_iterations,
             work_dir,
             julia_version,
-            include_subpackages)
+            include_subpackages
+        )
 
         if !success || isempty(all_updates)
             @info "No changes needed for $repo_name"
@@ -637,10 +651,12 @@ function fix_repo_min_versions(repo_name::String;
     else
         # Fix minimum versions for single project
         success,
-        updates = fix_package_min_versions(repo_dir;
+            updates = fix_package_min_versions(
+            repo_dir;
             max_iterations,
             work_dir,
-            julia_version)
+            julia_version
+        )
 
         if !success || isempty(updates)
             @info "No changes needed for $repo_name"
@@ -769,14 +785,16 @@ end
 Fix minimum versions for all Julia packages in a GitHub organization.
 Now supports repositories with subpackages in /lib directories.
 """
-function fix_org_min_versions(org_name::String;
+function fix_org_min_versions(
+        org_name::String;
         work_dir::String = mktempdir(),
         max_iterations::Int = 10,
         create_prs::Bool = true,
         skip_repos::Vector{String} = String[],
         only_repos::Union{Nothing, Vector{String}} = nothing,
         julia_version::String = "1.10",
-        include_subpackages::Bool = true)
+        include_subpackages::Bool = true
+    )
     @info "Fetching repositories for organization: $org_name"
 
     # Get repositories
@@ -791,10 +809,14 @@ function fix_org_min_versions(org_name::String;
         repos = String[]
         for repo in repos_data
             if !repo.isArchived &&
-               (endswith(repo.name, ".jl") ||
-                (haskey(repo, :description) &&
-                 repo.description !== nothing &&
-                 occursin("julia", lowercase(repo.description))))
+                    (
+                    endswith(repo.name, ".jl") ||
+                        (
+                        haskey(repo, :description) &&
+                            repo.description !== nothing &&
+                            occursin("julia", lowercase(repo.description))
+                    )
+                )
                 push!(repos, "$org_name/$(repo.name)")
             end
         end
@@ -813,12 +835,14 @@ function fix_org_min_versions(org_name::String;
         @info "="^60
 
         try
-            success = fix_repo_min_versions(repo;
+            success = fix_repo_min_versions(
+                repo;
                 work_dir,
                 max_iterations,
                 create_pr = create_prs,
                 julia_version,
-                include_subpackages)
+                include_subpackages
+            )
             results[repo] = success
         catch e
             @error "Failed to process $repo: $e"

--- a/src/multiprocess_testing.jl
+++ b/src/multiprocess_testing.jl
@@ -17,9 +17,9 @@ struct TestGroup
     name::String
     env_vars::Dict{String, String}
     continue_on_error::Bool
-    
-    function TestGroup(name::String; env_vars=Dict{String, String}(), continue_on_error=false)
-        new(name, env_vars, continue_on_error)
+
+    function TestGroup(name::String; env_vars = Dict{String, String}(), continue_on_error = false)
+        return new(name, env_vars, continue_on_error)
     end
 end
 
@@ -47,30 +47,30 @@ function parse_ci_workflow(workflow_file::String)
     if !isfile(workflow_file)
         error("Workflow file not found: $workflow_file")
     end
-    
+
     yaml_content = YAML.load_file(workflow_file)
     test_groups = TestGroup[]
-    
+
     jobs = get(yaml_content, "jobs", Dict())
     test_job = get(jobs, "test", Dict())
     strategy = get(test_job, "strategy", Dict())
     matrix = get(strategy, "matrix", Dict())
-    
+
     groups = get(matrix, "group", String[])
-    
+
     continue_on_error_expr = get(test_job, "continue-on-error", false)
-    
+
     for group_name in groups
         continue_on_error = false
         if isa(continue_on_error_expr, String) && contains(continue_on_error_expr, "matrix.group")
             continue_on_error = contains(continue_on_error_expr, "'$group_name'")
         end
-        
+
         env_vars = Dict("GROUP" => group_name)
-        
-        push!(test_groups, TestGroup(group_name; env_vars=env_vars, continue_on_error=continue_on_error))
+
+        push!(test_groups, TestGroup(group_name; env_vars = env_vars, continue_on_error = continue_on_error))
     end
-    
+
     return test_groups
 end
 
@@ -78,16 +78,16 @@ function setup_test_environment(project_path::String)
     if !isdir(project_path)
         error("Project path not found: $project_path")
     end
-    
+
     cd(project_path)
-    
+
     Pkg.activate(".")
-    
-    try
+
+    return try
         Pkg.resolve()
         @info "Project environment activated and resolved" project_path
     catch e
-        @warn "Failed to resolve project environment" exception=e
+        @warn "Failed to resolve project environment" exception = e
         rethrow(e)
     end
 end
@@ -95,30 +95,30 @@ end
 function run_single_test_group(group::TestGroup, project_path::String, log_dir::String)
     start_time = now()
     log_file = joinpath(log_dir, "$(group.name).log")
-    
+
     mkpath(log_dir)
-    
+
     io = open(log_file, "w")
     logger = SimpleLogger(io)
-    
+
     success = false
     error_message = nothing
-    
+
     try
         with_logger(logger) do
-            @info "Starting test group: $(group.name)" timestamp=start_time
+            @info "Starting test group: $(group.name)" timestamp = start_time
             @info "Project path: $project_path"
             @info "Environment variables: $(group.env_vars)"
-            
+
             for (key, value) in group.env_vars
                 ENV[key] = value
                 @info "Set environment variable: $key = $value"
             end
-            
+
             cd(project_path)
-            
+
             @info "Running Pkg.test()..."
-            
+
             redirect_stdout(io) do
                 redirect_stderr(io) do
                     try
@@ -126,7 +126,7 @@ function run_single_test_group(group::TestGroup, project_path::String, log_dir::
                         @info "Test completed successfully"
                         success = true
                     catch e
-                        @error "Test failed with exception" exception=e
+                        @error "Test failed with exception" exception = e
                         error_message = string(e)
                         if !group.continue_on_error
                             rethrow(e)
@@ -138,60 +138,62 @@ function run_single_test_group(group::TestGroup, project_path::String, log_dir::
     catch e
         error_message = string(e)
         with_logger(logger) do
-            @error "Fatal error during test execution" exception=e
+            @error "Fatal error during test execution" exception = e
         end
     finally
         close(io)
-        
+
         for key in keys(group.env_vars)
             delete!(ENV, key)
         end
     end
-    
+
     end_time = now()
     duration = (end_time - start_time).value / 1000.0
-    
+
     return TestResult(group, success, duration, log_file, error_message, start_time, end_time)
 end
 
-function run_multiprocess_tests(workflow_file::String, project_path::String; 
-                               log_dir::String="test_logs", max_workers::Int=4)
-    
+function run_multiprocess_tests(
+        workflow_file::String, project_path::String;
+        log_dir::String = "test_logs", max_workers::Int = 4
+    )
+
     start_time = now()
-    
+
     @info "Parsing CI workflow file: $workflow_file"
     test_groups = parse_ci_workflow(workflow_file)
     @info "Found $(length(test_groups)) test groups"
-    
+
     @info "Setting up test environment"
     setup_test_environment(project_path)
-    
+
     log_dir = abspath(log_dir)
     mkpath(log_dir)
     @info "Logs will be written to: $log_dir"
-    
+
     current_workers = nprocs() - 1
     needed_workers = min(max_workers, length(test_groups)) - current_workers
-    
+
     if needed_workers > 0
         @info "Adding $needed_workers worker processes"
         addprocs(needed_workers)
-        
+
         @everywhere using Pkg, Dates, Logging
     end
-    
+
     @info "Running tests with $(nprocs() - 1) worker processes"
-    
+
     results = pmap(test_groups) do group
         run_single_test_group(group, project_path, log_dir)
     end
-    
+
     end_time = now()
     total_duration = (end_time - start_time).value / 1000.0
-    
+
     passed_groups = count(r -> r.success, results)
     failed_groups = length(results) - passed_groups
-    
+
     summary = TestSummary(
         length(test_groups),
         passed_groups,
@@ -201,52 +203,52 @@ function run_multiprocess_tests(workflow_file::String, project_path::String;
         start_time,
         end_time
     )
-    
+
     return summary
 end
 
-function generate_test_summary_report(summary::TestSummary, output_file::Union{String, Nothing}=nothing)
+function generate_test_summary_report(summary::TestSummary, output_file::Union{String, Nothing} = nothing)
     io = IOBuffer()
-    
+
     println(io, "="^80)
     println(io, "MULTIPROCESS TEST SUMMARY REPORT")
     println(io, "="^80)
     println(io)
-    
+
     println(io, "Start Time: $(summary.start_time)")
     println(io, "End Time: $(summary.end_time)")
     println(io, "Total Duration: $(@sprintf("%.2f", summary.total_duration)) seconds")
     println(io)
-    
+
     println(io, "Test Results:")
     println(io, "  Total Groups: $(summary.total_groups)")
     println(io, "  Passed: $(summary.passed_groups)")
     println(io, "  Failed: $(summary.failed_groups)")
     println(io, "  Success Rate: $(@sprintf("%.1f", (summary.passed_groups / summary.total_groups) * 100))%")
     println(io)
-    
-    sorted_results = sort(summary.results, by=r -> r.duration, rev=true)
-    
+
+    sorted_results = sort(summary.results, by = r -> r.duration, rev = true)
+
     println(io, "Individual Test Group Results:")
     println(io, "-"^80)
-    
+
     for result in sorted_results
         status = result.success ? "✓ PASS" : "✗ FAIL"
         duration_str = @sprintf("%8.2fs", result.duration)
-        
+
         println(io, "$status $duration_str $(result.group.name)")
-        
+
         if !result.success && result.error_message !== nothing
-            error_preview = length(result.error_message) > 100 ? 
-                            result.error_message[1:100] * "..." : 
-                            result.error_message
+            error_preview = length(result.error_message) > 100 ?
+                result.error_message[1:100] * "..." :
+                result.error_message
             println(io, "    Error: $error_preview")
         end
-        
+
         println(io, "    Log: $(result.log_file)")
         println(io)
     end
-    
+
     failed_results = filter(r -> !r.success, summary.results)
     if !isempty(failed_results)
         println(io, "FAILED GROUPS SUMMARY:")
@@ -260,16 +262,16 @@ function generate_test_summary_report(summary::TestSummary, output_file::Union{S
             println(io)
         end
     end
-    
+
     report = String(take!(io))
-    
+
     if output_file !== nothing
         open(output_file, "w") do f
             write(f, report)
         end
         @info "Test summary report written to: $output_file"
     end
-    
+
     return report
 end
 
@@ -278,40 +280,42 @@ function print_test_summary(summary::TestSummary)
     println("="^60)
     println("TEST SUMMARY")
     println("="^60)
-    
+
     success_rate = (summary.passed_groups / summary.total_groups) * 100
-    
+
     status_color = summary.failed_groups == 0 ? :green : :red
-    
-    printstyled("Total: $(summary.total_groups) | ", color=:blue)
-    printstyled("Passed: $(summary.passed_groups) | ", color=:green)  
-    printstyled("Failed: $(summary.failed_groups) | ", color=:red)
-    printstyled(@sprintf("Success: %.1f%%", success_rate), color=status_color)
+
+    printstyled("Total: $(summary.total_groups) | ", color = :blue)
+    printstyled("Passed: $(summary.passed_groups) | ", color = :green)
+    printstyled("Failed: $(summary.failed_groups) | ", color = :red)
+    printstyled(@sprintf("Success: %.1f%%", success_rate), color = status_color)
     println()
-    
-    printstyled(@sprintf("Duration: %.2f seconds", summary.total_duration), color=:blue)
+
+    printstyled(@sprintf("Duration: %.2f seconds", summary.total_duration), color = :blue)
     println()
-    
+
     if summary.failed_groups > 0
         println("\nFailed Groups:")
         for result in filter(r -> !r.success, summary.results)
-            printstyled("  • $(result.group.name)", color=:red)
+            printstyled("  • $(result.group.name)", color = :red)
             println(" ($(result.log_file))")
         end
     end
-    
-    println("="^60)
+
+    return println("="^60)
 end
 
-function run_tests_from_repo(repo_url::String; branch::String="master", 
-                            workflow_path::String=".github/workflows/CI.yml",
-                            log_dir::String="test_logs")
-    
+function run_tests_from_repo(
+        repo_url::String; branch::String = "master",
+        workflow_path::String = ".github/workflows/CI.yml",
+        log_dir::String = "test_logs"
+    )
+
     repo_name = split(repo_url, "/")[end]
     if endswith(repo_name, ".git")
-        repo_name = repo_name[1:end-4]
+        repo_name = repo_name[1:(end - 4)]
     end
-    
+
     if !isdir(repo_name)
         @info "Cloning repository: $repo_url"
         run(`git clone -b $branch $repo_url $repo_name`)
@@ -321,9 +325,9 @@ function run_tests_from_repo(repo_url::String; branch::String="master",
             run(`git pull origin $branch`)
         end
     end
-    
+
     project_path = abspath(repo_name)
     workflow_file = joinpath(project_path, workflow_path)
-    
-    return run_multiprocess_tests(workflow_file, project_path; log_dir=log_dir)
+
+    return run_multiprocess_tests(workflow_file, project_path; log_dir = log_dir)
 end

--- a/src/version_bumping.jl
+++ b/src/version_bumping.jl
@@ -159,7 +159,7 @@ function register_package(package_dir::String; registry = "General", push::Bool 
         if e isa ErrorException
             @error "Failed to register package at $package_dir: $(e.msg)"
         else
-            @error "Failed to register package at $package_dir" exception=(e, catch_backtrace())
+            @error "Failed to register package at $package_dir" exception = (e, catch_backtrace())
         end
         return false
     end
@@ -210,20 +210,20 @@ function bump_and_register_repo(repo_path::String; registry = "General", push::B
     # First, bump all versions
     @info "Bumping versions for all packages in $repo_path"
     version_updates = update_project_versions_all(repo_path)
-    
+
     if isempty(version_updates)
         @info "No packages found to update"
         return (registered = String[], failed = String[])
     end
-    
+
     # Collect all package directories
     package_dirs = String[]
-    
+
     # Main package
     if isfile(joinpath(repo_path, "Project.toml"))
         push!(package_dirs, repo_path)
     end
-    
+
     # Subpackages in lib/
     lib_dir = joinpath(repo_path, "lib")
     if isdir(lib_dir)
@@ -234,17 +234,17 @@ function bump_and_register_repo(repo_path::String; registry = "General", push::B
             end
         end
     end
-    
+
     # Register packages using brute-force dependency resolution
     registered = Set{String}()
-    
+
     while true
         one_succeed = false
-        
+
         for package_dir in package_dirs
             package_name = basename(package_dir)
             package_name in registered && continue
-            
+
             @info "Trying to register $package_name"
             # We need to register the packages in the correct order so we just brute force try
             # one by one until it succeeds
@@ -259,17 +259,17 @@ function bump_and_register_repo(repo_path::String; registry = "General", push::B
                     @debug "Could not register $package_name yet: $(e.msg)"
                 else
                     # Unexpected error - log but continue
-                    @error "Unexpected error registering $package_name" exception=(e, catch_backtrace())
+                    @error "Unexpected error registering $package_name" exception = (e, catch_backtrace())
                 end
             end
         end
-        
+
         if !one_succeed
             # No more packages can be registered
             break
         end
     end
-    
+
     # Identify failed packages
     failed_packages = String[]
     for package_dir in package_dirs
@@ -278,7 +278,7 @@ function bump_and_register_repo(repo_path::String; registry = "General", push::B
             push!(failed_packages, package_name)
         end
     end
-    
+
     if !isempty(failed_packages)
         @error "Could not register the following packages: $(join(failed_packages, ", "))"
     end
@@ -344,15 +344,15 @@ function register_monorepo_packages(repo_path::String; registry = "General", pus
     if !isdir(repo_path)
         error("Repository path does not exist: $repo_path")
     end
-    
+
     # Collect all package directories
     package_dirs = String[]
-    
+
     # Main package
     if isfile(joinpath(repo_path, "Project.toml"))
         push!(package_dirs, repo_path)
     end
-    
+
     # Subpackages in lib/
     lib_dir = joinpath(repo_path, "lib")
     if isdir(lib_dir)
@@ -363,24 +363,24 @@ function register_monorepo_packages(repo_path::String; registry = "General", pus
             end
         end
     end
-    
+
     if isempty(package_dirs)
         @info "No packages found to register"
         return (registered = String[], failed = String[])
     end
-    
+
     @info "Found $(length(package_dirs)) packages to register"
-    
+
     # Register packages using brute-force dependency resolution
     registered = Set{String}()
-    
+
     while true
         one_succeed = false
-        
+
         for package_dir in package_dirs
             package_name = basename(package_dir)
             package_name in registered && continue
-            
+
             @info "Trying to register $package_name"
             # We need to register the packages in the correct order so we just brute force try
             # one by one until it succeeds
@@ -395,17 +395,17 @@ function register_monorepo_packages(repo_path::String; registry = "General", pus
                     @debug "Could not register $package_name yet: $(e.msg)"
                 else
                     # Unexpected error - log but continue
-                    @error "Unexpected error registering $package_name" exception=(e, catch_backtrace())
+                    @error "Unexpected error registering $package_name" exception = (e, catch_backtrace())
                 end
             end
         end
-        
+
         if !one_succeed
             @info "Could not register any more packages"
             break
         end
     end
-    
+
     # Identify failed packages
     failed_packages = String[]
     for package_dir in package_dirs
@@ -414,11 +414,11 @@ function register_monorepo_packages(repo_path::String; registry = "General", pus
             push!(failed_packages, package_name)
         end
     end
-    
+
     if !isempty(failed_packages)
         @error "Could not register the following packages: $(join(failed_packages, ", "))"
     end
-    
+
     return (registered = collect(registered), failed = failed_packages)
 end
 
@@ -483,7 +483,7 @@ function get_org_repos(org::String; auth_token::String = "")
 
             page += 1
         catch e
-            @error "Failed to fetch repos" page exception=(e, catch_backtrace())
+            @error "Failed to fetch repos" page exception = (e, catch_backtrace())
             break
         end
     end
@@ -552,11 +552,13 @@ results = bump_and_register_org("MyOrg";
 - [`bump_and_register_repo`](@ref): For processing a single repository
 - [`get_org_repos`](@ref): For fetching organization repository list
 """
-function bump_and_register_org(org::String;
+function bump_and_register_org(
+        org::String;
         registry = "General",
         push::Bool = false,
         auth_token::String = "",
-        work_dir::String = mktempdir())
+        work_dir::String = mktempdir()
+    )
     @info "Fetching repositories for organization: $org"
     repos = get_org_repos(org; auth_token)
 
@@ -597,9 +599,10 @@ function bump_and_register_org(org::String;
             end
 
         catch e
-            @error "Failed to process $repo_name" exception=(e, catch_backtrace())
+            @error "Failed to process $repo_name" exception = (e, catch_backtrace())
             results[repo_name] = (
-                registered = String[], failed = String[], error = string(e))
+                registered = String[], failed = String[], error = string(e),
+            )
         finally
             # Clean up
             rm(repo_dir; force = true, recursive = true)
@@ -611,9 +614,9 @@ end
 
 # Keep the placeholder functions for backward compatibility
 function update_manifests()
-    @warn "update_manifests is deprecated. Use bump_and_register_repo or bump_and_register_org instead."
+    return @warn "update_manifests is deprecated. Use bump_and_register_repo or bump_and_register_org instead."
 end
 
 function update_project_tomls()
-    @warn "update_project_tomls is deprecated. Use bump_and_register_repo or bump_and_register_org instead."
+    return @warn "update_project_tomls is deprecated. Use bump_and_register_repo or bump_and_register_org instead."
 end

--- a/src/version_check_finder.jl
+++ b/src/version_check_finder.jl
@@ -10,7 +10,7 @@ const VERSION_CHECK_PATTERNS = [
     r"^\s*elseif\s+VERSION\s*[><=]=?\s*v\"(\d+\.\d+(?:\.\d+)?)\""im,
     r"VERSION\s*[><=]=?\s*v\"(\d+\.\d+(?:\.\d+)?)\"\s*&&"i,
     r"VERSION\s*[><=]=?\s*v\"(\d+\.\d+(?:\.\d+)?)\"\s*\|\|"i,
-    r"VERSION\s*[><=]=?\s*VersionNumber\(\"(\d+\.\d+(?:\.\d+)?)\"\)"i
+    r"VERSION\s*[><=]=?\s*VersionNumber\(\"(\d+\.\d+(?:\.\d+)?)\"\)"i,
 ]
 
 const JULIA_LTS = v"1.10"
@@ -48,19 +48,21 @@ function find_version_checks_in_file(filepath::String; min_version::VersionNumbe
                     version = VersionNumber(version_str)
 
                     if version < min_version
-                        push!(checks, VersionCheck(
-                            filepath,
-                            line_num,
-                            line,
-                            version,
-                            m.match
-                        ))
+                        push!(
+                            checks, VersionCheck(
+                                filepath,
+                                line_num,
+                                line,
+                                version,
+                                m.match
+                            )
+                        )
                     end
                 end
             end
         end
     catch e
-        @error "Error reading file $filepath" exception=(e, catch_backtrace())
+        @error "Error reading file $filepath" exception = (e, catch_backtrace())
     end
 
     return checks
@@ -71,9 +73,11 @@ end
 
 Find all version checks in a repository that compare against versions older than min_version.
 """
-function find_version_checks_in_repo(repo_path::String;
+function find_version_checks_in_repo(
+        repo_path::String;
         min_version::VersionNumber = JULIA_LTS,
-        ignore_dirs = ["test", "docs", ".git"])
+        ignore_dirs = ["test", "docs", ".git"]
+    )
     if !isdir(repo_path)
         error("Repository path does not exist: $repo_path")
     end
@@ -105,11 +109,13 @@ end
 
 Find all version checks in all repositories of a GitHub organization.
 """
-function find_version_checks_in_org(org::String;
+function find_version_checks_in_org(
+        org::String;
         min_version::VersionNumber = JULIA_LTS,
         auth_token::String = "",
         work_dir::String = mktempdir(),
-        ignore_dirs = ["test", "docs", ".git"])
+        ignore_dirs = ["test", "docs", ".git"]
+    )
     results = Dict{String, Vector{VersionCheck}}()
 
     @info "Fetching repositories for organization: $org"
@@ -137,7 +143,7 @@ function find_version_checks_in_org(org::String;
             end
 
         catch e
-            @error "Failed to process $repo_name" exception=(e, catch_backtrace())
+            @error "Failed to process $repo_name" exception = (e, catch_backtrace())
         finally
             rm(repo_dir; force = true, recursive = true)
         end
@@ -152,7 +158,8 @@ end
 Write version check results to a Julia script file that can be executed to fix them.
 """
 function write_version_checks_to_script(
-        checks::Vector{VersionCheck}, output_file::String = "fix_version_checks.jl")
+        checks::Vector{VersionCheck}, output_file::String = "fix_version_checks.jl"
+    )
     open(output_file, "w") do io
         println(io, "#!/usr/bin/env julia")
         println(io, "# Auto-generated script to fix version checks")
@@ -197,7 +204,8 @@ Write organization-wide version check results to a script file.
 """
 function write_org_version_checks_to_script(
         org_results::Dict{String, Vector{VersionCheck}},
-        output_file::String = "fix_org_version_checks.jl")
+        output_file::String = "fix_org_version_checks.jl"
+    )
     total_checks = sum(length(checks) for checks in values(org_results))
 
     open(output_file, "w") do io
@@ -251,10 +259,12 @@ end
 Fix version checks in parallel using N processes. Each process will create a PR
 to fix the version checks by removing obsolete comparisons.
 """
-function fix_version_checks_parallel(checks::Vector{VersionCheck}, n_processes::Int = 4;
+function fix_version_checks_parallel(
+        checks::Vector{VersionCheck}, n_processes::Int = 4;
         github_token::String = "",
         base_branch::String = "main",
-        pr_title_prefix::String = "[Auto] Remove obsolete version checks")
+        pr_title_prefix::String = "[Auto] Remove obsolete version checks"
+    )
     if isempty(github_token)
         error("GitHub token is required for creating PRs")
     end
@@ -282,7 +292,8 @@ function fix_version_checks_parallel(checks::Vector{VersionCheck}, n_processes::
     # Define the worker function
     @everywhere function process_repo_fixes(
             repo_path::String, repo_checks::Vector{VersionCheck},
-            github_token::String, base_branch::String, pr_title_prefix::String)
+            github_token::String, base_branch::String, pr_title_prefix::String
+        )
         try
             # Create a temporary directory for Claude to work in
             work_dir = mktempdir()
@@ -352,7 +363,8 @@ function fix_version_checks_parallel(checks::Vector{VersionCheck}, n_processes::
     # Process repositories in parallel
     results = pmap(pairs(checks_by_repo)) do (repo_path, repo_checks)
         process_repo_fixes(
-            repo_path, repo_checks, github_token, base_branch, pr_title_prefix)
+            repo_path, repo_checks, github_token, base_branch, pr_title_prefix
+        )
     end
 
     # Summarize results
@@ -373,11 +385,13 @@ end
 
 Find and fix version checks across an entire GitHub organization using parallel processing.
 """
-function fix_org_version_checks_parallel(org::String, n_processes::Int = 4;
+function fix_org_version_checks_parallel(
+        org::String, n_processes::Int = 4;
         min_version::VersionNumber = JULIA_LTS,
         github_token::String = "",
         base_branch::String = "main",
-        work_dir::String = mktempdir())
+        work_dir::String = mktempdir()
+    )
 
     # First, find all version checks
     @info "Finding version checks in organization: $org"

--- a/test/documentation_cleanup_tests.jl
+++ b/test/documentation_cleanup_tests.jl
@@ -1,17 +1,17 @@
 # Note: OrgMaintenanceScripts is already loaded by runtests.jl
 
 @testset "Documentation Cleanup Tests" begin
-    
+
     @testset "Input Validation" begin
         # Test invalid repository path
         @test_throws ArgumentError cleanup_gh_pages_docs("/nonexistent/path")
-        
+
         # Test non-git directory
         mktempdir() do tmpdir
             @test_throws ArgumentError cleanup_gh_pages_docs(tmpdir)
         end
     end
-    
+
     @testset "Mock Repository Tests" begin
         # Create a mock git repository for testing
         mktempdir() do tmpdir
@@ -20,69 +20,69 @@
                 run(`git init`)
                 run(`git config user.email "test@example.com"`)
                 run(`git config user.name "Test User"`)
-                
+
                 # Create main branch with initial commit
                 write("README.md", "# Test Repository")
                 run(`git add README.md`)
                 run(`git commit -m "Initial commit"`)
-                
+
                 @testset "No gh-pages Branch" begin
                     # Test with repository that has no gh-pages branch
-                    result = cleanup_gh_pages_docs(tmpdir, dry_run=true)
+                    result = cleanup_gh_pages_docs(tmpdir, dry_run = true)
                     @test result.success == true
                     @test result.files_removed == 0
                 end
-                
+
                 @testset "With gh-pages Branch" begin
                     # Create gh-pages branch with mock documentation
                     run(`git checkout --orphan gh-pages`)
-                    
+
                     # Create mock version directories
                     mkdir("v1.0.0")
-                    mkdir("v1.1.0") 
+                    mkdir("v1.1.0")
                     mkdir("v2.0.0")
                     mkdir("dev")
                     mkdir("previews")
-                    
+
                     # Create mock files in version directories
                     write("v1.0.0/index.html", "Old version 1.0.0 docs")
-                    write("v1.1.0/index.html", "Old version 1.1.0 docs")  
+                    write("v1.1.0/index.html", "Old version 1.1.0 docs")
                     write("v2.0.0/index.html", "Latest version 2.0.0 docs")
                     write("dev/index.html", "Development docs")
                     write("previews/index.html", "Preview docs")
-                    
+
                     # Create a large mock file
                     large_content = repeat("X", 6 * 1024 * 1024)  # 6MB file
                     write("v1.0.0/large_plot.svg", large_content)
-                    
+
                     run(`git add .`)
                     run(`git commit -m "Add mock documentation"`)
-                    
+
                     @testset "Dry Run Mode" begin
-                        result = cleanup_gh_pages_docs(tmpdir, dry_run=true)
-                        
-                        @test result.success == true  
+                        result = cleanup_gh_pages_docs(tmpdir, dry_run = true)
+
+                        @test result.success == true
                         @test result.dirs_removed >= 2  # Should identify dev, previews, old versions
-                        
+
                         # Files should still exist after dry run
                         @test isdir("v1.0.0")
                         @test isdir("dev")
                         @test isfile("v1.0.0/large_plot.svg")
                     end
-                    
+
                     @testset "Preserve Latest Version" begin
-                        result = cleanup_gh_pages_docs(tmpdir, preserve_latest=true)
-                        
+                        result = cleanup_gh_pages_docs(tmpdir, preserve_latest = true)
+
                         @test result.success == true
                         @test result.preserved_version == "v2.0.0"
                         @test "v1.0.0" in result.versions_cleaned
                         @test "v1.1.0" in result.versions_cleaned
                         @test !("v2.0.0" in result.versions_cleaned)
-                        
+
                         # Latest version should still exist
                         @test isdir("v2.0.0")
                         @test isfile("v2.0.0/index.html")
-                        
+
                         # Old versions should be removed
                         @test !isdir("v1.0.0")
                         @test !isdir("v1.1.0")
@@ -93,7 +93,7 @@
             end
         end
     end
-    
+
     @testset "Analysis Function" begin
         mktempdir() do tmpdir
             cd(tmpdir) do
@@ -101,26 +101,26 @@
                 run(`git init`)
                 run(`git config user.email "test@example.com"`)
                 run(`git config user.name "Test User"`)
-                
+
                 write("README.md", "# Test")
                 run(`git add README.md`)
                 run(`git commit -m "Initial commit"`)
-                
+
                 # Test analysis with no gh-pages
                 analysis = analyze_gh_pages_bloat(tmpdir)
                 @test analysis.total_size_mb == 0.0
                 @test isempty(analysis.large_files)
                 @test analysis.analysis == "No gh-pages branch"
-                
+
                 # Create gh-pages with content
                 run(`git checkout --orphan gh-pages`)
                 mkdir("v1.0.0")
                 write("v1.0.0/small.html", "small file")
                 write("v1.0.0/large.html", repeat("X", 2 * 1024 * 1024))  # 2MB
-                
+
                 run(`git add .`)
                 run(`git commit -m "Add docs"`)
-                
+
                 analysis = analyze_gh_pages_bloat(tmpdir)
                 @test analysis.total_size_mb > 0
                 @test !isempty(analysis.versions)
@@ -129,16 +129,16 @@
             end
         end
     end
-    
+
     @testset "Organization Cleanup" begin
         # Test with empty repository list
-        results = cleanup_org_gh_pages_docs(String[], dry_run=true)
+        results = cleanup_org_gh_pages_docs(String[], dry_run = true)
         @test isempty(results)
-        
+
         # Test with invalid repository URLs would require actual network access
         # So we'll skip this for unit tests
     end
-    
+
     @testset "Integration Test - Full Workflow" begin
         mktempdir() do tmpdir
             cd(tmpdir) do
@@ -146,33 +146,35 @@
                 run(`git init`)
                 run(`git config user.email "test@example.com"`)
                 run(`git config user.name "Test User"`)
-                
+
                 # Main branch
                 write("README.md", "# Test Package")
                 mkdir("src")
                 write("src/Package.jl", "module Package end")
                 run(`git add .`)
                 run(`git commit -m "Initial package"`)
-                
+
                 # Create tags (simulating releases)
                 run(`git tag v1.0.0`)
                 run(`git tag v2.0.0`)
-                
+
                 # Create gh-pages with documentation
                 run(`git checkout --orphan gh-pages`)
-                
+
                 # Create realistic documentation structure
                 for version in ["v1.0.0", "v1.5.0", "v2.0.0"]
                     mkdir(version)
                     mkdir("$version/tutorials")
-                    
+
                     # Create realistic documentation files
-                    write("$version/index.html", """
-                    <!DOCTYPE html>
-                    <html><head><title>Docs $version</title></head>
-                    <body><h1>Documentation $version</h1></body></html>
-                    """)
-                    
+                    write(
+                        "$version/index.html", """
+                        <!DOCTYPE html>
+                        <html><head><title>Docs $version</title></head>
+                        <body><h1>Documentation $version</h1></body></html>
+                        """
+                    )
+
                     # Simulate large tutorial with embedded plots
                     large_tutorial = """
                     <!DOCTYPE html><html><head><title>Tutorial</title></head><body>
@@ -182,39 +184,39 @@
                     """
                     write("$version/tutorials/example.html", large_tutorial)
                 end
-                
+
                 # Add development and preview docs
                 mkdir("dev")
                 write("dev/index.html", "Development documentation")
-                
+
                 mkdir("previews")
-                mkdir("previews/PR123") 
+                mkdir("previews/PR123")
                 write("previews/PR123/index.html", "PR preview docs")
-                
+
                 run(`git add .`)
                 run(`git commit -m "Add comprehensive documentation"`)
-                
+
                 # Test analysis first
                 analysis = analyze_gh_pages_bloat(tmpdir)
                 @test analysis.total_size_mb > 1.0  # Should have large files
                 @test length(analysis.versions) == 3
                 @test analysis.latest_version == "v2.0.0"
-                
+
                 # Test cleanup preserving latest
-                result = cleanup_gh_pages_docs(tmpdir, preserve_latest=true)
-                
+                result = cleanup_gh_pages_docs(tmpdir, preserve_latest = true)
+
                 @test result.success == true
                 @test result.preserved_version == "v2.0.0"
                 @test result.files_removed > 0
                 @test "v1.0.0" in result.versions_cleaned
                 @test "dev" in result.versions_cleaned
-                
+
                 # Verify final state
                 @test isdir("v2.0.0")  # Latest preserved
                 @test !isdir("v1.0.0")  # Old version removed
                 @test !isdir("dev")     # Dev docs removed
                 @test !isdir("previews") # Preview docs removed
-                
+
                 # Verify git history was updated
                 last_commit = readchomp(`git log -1 --format=%s`)
                 @test contains(last_commit, "Clean up old documentation")

--- a/test/explicit_imports_fixer_tests.jl
+++ b/test/explicit_imports_fixer_tests.jl
@@ -27,15 +27,17 @@
         mktempdir() do tmpdir
             # Create a test file
             test_file = joinpath(tmpdir, "test.jl")
-            write(test_file, """
-            module TestModule
+            write(
+                test_file, """
+                module TestModule
 
-            function test_func()
-                println("Hello")
-            end
+                function test_func()
+                    println("Hello")
+                end
 
-            end
-            """)
+                end
+                """
+            )
 
             # Fix missing import
             success = OrgMaintenanceScripts.fix_missing_import(test_file, "Base", "println")
@@ -51,19 +53,21 @@
         mktempdir() do tmpdir
             # Create a test file with unused imports
             test_file = joinpath(tmpdir, "test.jl")
-            write(test_file, """
-            module TestModule
+            write(
+                test_file, """
+                module TestModule
 
-            using Base: println, push!, pop!
-            using Test: @test
+                using Base: println, push!, pop!
+                using Test: @test
 
-            function test_func()
-                println("Hello")
-                # push! and pop! are not used
-            end
+                function test_func()
+                    println("Hello")
+                    # push! and pop! are not used
+                end
 
-            end
-            """)
+                end
+                """
+            )
 
             # Remove unused import
             success = OrgMaintenanceScripts.fix_unused_import(test_file, "push!")
@@ -72,7 +76,7 @@
             # Check the file was modified correctly
             content = read(test_file, String)
             @test occursin("using Base: println, pop!", content) ||
-                  occursin("using Base: pop!, println", content)
+                occursin("using Base: pop!, println", content)
             # Check that push! is not in the using statement (it can still be in comments)
             lines = split(content, '\n')
             using_lines = filter(line -> occursin(r"^\s*using\s+Base:", line), lines)
@@ -97,20 +101,22 @@
             end
 
             # Create source file with import issues
-            write(joinpath(pkg_dir, "src", "MockPackage.jl"), """
-            module MockPackage
+            write(
+                joinpath(pkg_dir, "src", "MockPackage.jl"), """
+                module MockPackage
 
-            using Base: push!  # This might be unused
+                using Base: push!  # This might be unused
 
-            export greet
+                export greet
 
-            function greet(name)
-                println("Hello, \$name!")  # println not explicitly imported
-                return nothing
-            end
+                function greet(name)
+                    println("Hello, \$name!")  # println not explicitly imported
+                    return nothing
+                end
 
-            end
-            """)
+                end
+                """
+            )
 
             # Note: We can't fully test the fix_explicit_imports function here
             # because it requires ExplicitImports.jl to be installed and working

--- a/test/formatting_tests.jl
+++ b/test/formatting_tests.jl
@@ -6,7 +6,7 @@ using Pkg
         # Test with missing fork_user when create_pr=true
         # Now it tries to auto-detect from gh CLI
         success, message,
-        pr_url = format_repository(
+            pr_url = format_repository(
             "https://github.com/test/test.jl.git";
             create_pr = true,
             fork_user = ""
@@ -18,11 +18,11 @@ using Pkg
         @test pr_url === nothing
         # Check for either error message
         @test occursin("fork_user must be provided when create_pr=true (or configure gh CLI)", message) ||
-              occursin("Error:", message)
+            occursin("Error:", message)
 
         # Test with both push_to_master and create_pr
         success, message,
-        pr_url = format_repository(
+            pr_url = format_repository(
             "https://github.com/test/test.jl.git";
             push_to_master = true,
             create_pr = true,

--- a/test/import_timing_analysis_tests.jl
+++ b/test/import_timing_analysis_tests.jl
@@ -6,43 +6,47 @@
 
     # Create Project.toml
     project_toml = joinpath(test_dir, "Project.toml")
-    write(project_toml, """
-    name = "TestImportTimingPackage"
-    uuid = "12345678-1234-1234-1234-123456789def"
-    version = "0.1.0"
+    write(
+        project_toml, """
+        name = "TestImportTimingPackage"
+        uuid = "12345678-1234-1234-1234-123456789def"
+        version = "0.1.0"
 
-    [deps]
-    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-    """)
+        [deps]
+        Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+        """
+    )
 
     # Create src directory and main file
     src_dir = joinpath(test_dir, "src")
     mkpath(src_dir)
 
     main_file = joinpath(src_dir, "TestImportTimingPackage.jl")
-    write(main_file, """
-    module TestImportTimingPackage
+    write(
+        main_file, """
+        module TestImportTimingPackage
 
-    using Dates
+        using Dates
 
-    # Simple function
-    function get_current_time()
-        return now()
-    end
-
-    # Function that might take some time to compile
-    function complex_computation(x::T) where T
-        result = zero(T)
-        for i in 1:100
-            result += sin(x * i) + cos(x * i)
+        # Simple function
+        function get_current_time()
+            return now()
         end
-        return result
-    end
 
-    export get_current_time, complex_computation
+        # Function that might take some time to compile
+        function complex_computation(x::T) where T
+            result = zero(T)
+            for i in 1:100
+                result += sin(x * i) + cos(x * i)
+            end
+            return result
+        end
 
-    end # module
-    """)
+        export get_current_time, complex_computation
+
+        end # module
+        """
+    )
 
     @testset "ImportTiming and ImportTimingReport structures" begin
         # Test ImportTiming
@@ -114,7 +118,7 @@
                     "is_precompile" => true,
                     "is_local" => true,
                     "line" => "  200.0 ms  TestPackage"
-                )
+                ),
             ],
             "raw_output" => "Mock @time_imports output",
             "total_entries" => 3

--- a/test/invalidation_analysis_tests.jl
+++ b/test/invalidation_analysis_tests.jl
@@ -6,56 +6,62 @@
 
     # Create Project.toml
     project_toml = joinpath(test_dir, "Project.toml")
-    write(project_toml, """
-    name = "TestInvalidationPackage"
-    uuid = "12345678-1234-1234-1234-123456789abc"
-    version = "0.1.0"
+    write(
+        project_toml, """
+        name = "TestInvalidationPackage"
+        uuid = "12345678-1234-1234-1234-123456789abc"
+        version = "0.1.0"
 
-    [deps]
-    """)
+        [deps]
+        """
+    )
 
     # Create src directory and main file
     src_dir = joinpath(test_dir, "src")
     mkpath(src_dir)
 
     main_file = joinpath(src_dir, "TestInvalidationPackage.jl")
-    write(main_file, """
-    module TestInvalidationPackage
+    write(
+        main_file, """
+        module TestInvalidationPackage
 
-    # Simple function that shouldn't cause invalidations
-    function simple_add(x::Int, y::Int)
-        return x + y
-    end
-
-    # Function with type instability (potential invalidation source)
-    function unstable_function(x)
-        if x > 0
-            return x
-        else
-            return "negative"
+        # Simple function that shouldn't cause invalidations
+        function simple_add(x::Int, y::Int)
+            return x + y
         end
-    end
 
-    export simple_add, unstable_function
+        # Function with type instability (potential invalidation source)
+        function unstable_function(x)
+            if x > 0
+                return x
+            else
+                return "negative"
+            end
+        end
 
-    end # module
-    """)
+        export simple_add, unstable_function
+
+        end # module
+        """
+    )
 
     # Create test directory and test file
     test_test_dir = joinpath(test_dir, "test")
     mkpath(test_test_dir)
 
     runtests_file = joinpath(test_test_dir, "runtests.jl")
-    write(runtests_file, """
-    using TestInvalidationPackage
-    using Test
+    write(
+        runtests_file, """
+        using TestInvalidationPackage
+        using Test
 
-    @testset "TestInvalidationPackage Tests" begin
-        @test simple_add(2, 3) == 5
-        @test unstable_function(1) == 1
-        @test unstable_function(-1) == "negative"
-    end
-    """)
+        @testset "TestInvalidationPackage Tests" begin
+            @test simple_add(2, 3) == 5
+            @test unstable_function(1) == 1
+            @test unstable_function(-1) == "negative"
+        end
+        """
+    )
 
     @testset "InvalidationEntry and InvalidationReport structures" begin
         # Test InvalidationEntry
@@ -124,12 +130,12 @@
                     "package" => "Package2",
                     "children_count" => 2,
                     "depth" => 0
-                )
+                ),
             ]
         )
 
         major_invalidators,
-        package_impact = OrgMaintenanceScripts.analyze_major_invalidators(mock_data)
+            package_impact = OrgMaintenanceScripts.analyze_major_invalidators(mock_data)
 
         @test length(major_invalidators) == 3
         @test major_invalidators[1].children_count == 8  # Should be sorted by impact

--- a/test/jet_tests.jl
+++ b/test/jet_tests.jl
@@ -16,19 +16,22 @@ using JET
         # Create a temporary test file
         mktempdir() do tmpdir
             test_file = joinpath(tmpdir, "test.jl")
-            write(test_file, """
-                # Test file with version checks
-                @static if VERSION >= v"1.6"
-                    # Some code for Julia 1.6+
-                end
-                if VERSION < v"1.9"
-                    # Some code for older Julia
-                end
-            """)
+            write(
+                test_file, """
+                    # Test file with version checks
+                    @static if VERSION >= v"1.6"
+                        # Some code for Julia 1.6+
+                    end
+                    if VERSION < v"1.9"
+                        # Some code for older Julia
+                    end
+                """
+            )
 
             # Test that find_version_checks_in_file is type stable
             @test_opt target_modules = (OrgMaintenanceScripts,) OrgMaintenanceScripts.find_version_checks_in_file(
-                test_file)
+                test_file
+            )
         end
 
         # Test find_version_checks_in_repo with the current directory
@@ -39,9 +42,11 @@ using JET
     @testset "Version bumping functions" begin
         # Test bump_minor_version type stability
         @test_opt target_modules = (OrgMaintenanceScripts,) OrgMaintenanceScripts.bump_minor_version(
-            "1.0.0")
+            "1.0.0"
+        )
         @test_opt target_modules = (OrgMaintenanceScripts,) OrgMaintenanceScripts.bump_patch_version(
-            "1.0.0")
+            "1.0.0"
+        )
     end
 
     @testset "Struct constructors" begin
@@ -49,7 +54,8 @@ using JET
         @test_opt OrgMaintenanceScripts.VersionCheck("test.jl", 1, "test line", v"1.0", "v\"1.0\"")
         @test_opt OrgMaintenanceScripts.InvalidationEntry("method", "file.jl", 1, "pkg", "reason", 0, 0)
         @test_opt OrgMaintenanceScripts.InvalidationReport(
-            "repo", 0, OrgMaintenanceScripts.InvalidationEntry[], String[], Dates.now(), "summary", String[])
+            "repo", 0, OrgMaintenanceScripts.InvalidationEntry[], String[], Dates.now(), "summary", String[]
+        )
     end
 
     @testset "Report functions" begin
@@ -60,7 +66,8 @@ using JET
         mktempdir() do tmpdir
             output_file = joinpath(tmpdir, "output.jl")
             @test_opt target_modules = (OrgMaintenanceScripts,) OrgMaintenanceScripts.write_version_checks_to_script(
-                checks, output_file)
+                checks, output_file
+            )
         end
     end
 end

--- a/test/min_version_fixer_tests.jl
+++ b/test/min_version_fixer_tests.jl
@@ -31,12 +31,14 @@
 
     @testset "update_compat!" begin
         # Test preserving upper bounds
-        project = Dict("compat" => Dict{String, Any}(
-            "PkgA" => "0.5, 1",
-            "PkgB" => "0.3-0.5",
-            "PkgC" => "^1.2",
-            "PkgD" => "0.8"
-        ))
+        project = Dict(
+            "compat" => Dict{String, Any}(
+                "PkgA" => "0.5, 1",
+                "PkgB" => "0.3-0.5",
+                "PkgC" => "^1.2",
+                "PkgD" => "0.8"
+            )
+        )
 
         updates = Dict(
             "PkgA" => "0.7",
@@ -79,10 +81,10 @@
 
         project_toml = Dict(
             "deps" => Dict(
-            "RecursiveArrayTools" => "731186ca-5190-57fd-a4c3-8b3e5a648489",
-            "StaticArrays" => "90137ffa-7385-5640-81b9-e52037218182",
-            "SomeOtherPkg" => "12345678-1234-1234-1234-123456789012"
-        )
+                "RecursiveArrayTools" => "731186ca-5190-57fd-a4c3-8b3e5a648489",
+                "StaticArrays" => "90137ffa-7385-5640-81b9-e52037218182",
+                "SomeOtherPkg" => "12345678-1234-1234-1234-123456789012"
+            )
         )
 
         problematic = OrgMaintenanceScripts.parse_resolution_errors(error_output, project_toml)

--- a/test/multiprocess_testing_tests.jl
+++ b/test/multiprocess_testing_tests.jl
@@ -13,14 +13,14 @@ using Distributed
         @test group.name == "TestGroup1"
         @test group.env_vars == Dict{String, String}()
         @test group.continue_on_error == false
-        
+
         # Test with custom environment variables
         env_vars = Dict("GROUP" => "TestGroup1", "JULIA_NUM_THREADS" => "2")
-        group = TestGroup("TestGroup1", env_vars=env_vars)
+        group = TestGroup("TestGroup1", env_vars = env_vars)
         @test group.env_vars == env_vars
-        
+
         # Test continue on error
-        group = TestGroup("TestGroup1", continue_on_error=true)
+        group = TestGroup("TestGroup1", continue_on_error = true)
         @test group.continue_on_error == true
     end
 
@@ -53,38 +53,38 @@ using Distributed
                 env:
                   GROUP: \${{ matrix.group }}
         """
-        
+
         open(test_workflow, "w") do f
             write(f, workflow_content)
         end
-        
+
         try
             groups = parse_ci_workflow(test_workflow)
             @test length(groups) == 4
-            
+
             group_names = [g.name for g in groups]
             @test "InterfaceI" in group_names
             @test "InterfaceII" in group_names
             @test "Downstream" in group_names
             @test "OrdinaryDiffEqCore" in group_names
-            
+
             # Check environment variables
             for group in groups
                 @test haskey(group.env_vars, "GROUP")
                 @test group.env_vars["GROUP"] == group.name
             end
-            
+
             # Check continue-on-error logic
             downstream_group = first(g for g in groups if g.name == "Downstream")
             @test downstream_group.continue_on_error == true
-            
+
             interface_group = first(g for g in groups if g.name == "InterfaceI")
             @test interface_group.continue_on_error == false
-            
+
         finally
             rm(test_workflow)
         end
-        
+
         # Test with non-existent file
         @test_throws ErrorException parse_ci_workflow("nonexistent.yml")
     end
@@ -93,17 +93,17 @@ using Distributed
         # Test with current directory (should work)
         current_dir = pwd()
         @test_nowarn setup_test_environment(current_dir)
-        
+
         # Test with non-existent directory
         @test_throws ErrorException setup_test_environment("/nonexistent/path")
     end
 
     @testset "TestResult and TestSummary structures" begin
         # Create test data
-        group = TestGroup("TestGroup1", env_vars=Dict("GROUP" => "TestGroup1"))
+        group = TestGroup("TestGroup1", env_vars = Dict("GROUP" => "TestGroup1"))
         start_time = now()
         end_time = start_time + Millisecond(5000)
-        
+
         result = TestResult(
             group,
             true,  # success
@@ -113,17 +113,17 @@ using Distributed
             start_time,
             end_time
         )
-        
+
         @test result.group.name == "TestGroup1"
         @test result.success == true
         @test result.duration == 5.0
         @test result.log_file == "test.log"
         @test result.error_message === nothing
-        
+
         # Test TestSummary
         results = [result]
         summary = TestSummary(1, 1, 0, 5.0, results, start_time, end_time)
-        
+
         @test summary.total_groups == 1
         @test summary.passed_groups == 1
         @test summary.failed_groups == 0
@@ -135,15 +135,15 @@ using Distributed
         # Create mock test results
         group1 = TestGroup("PassingGroup")
         group2 = TestGroup("FailingGroup")
-        
+
         start_time = now()
         end_time = start_time + Millisecond(10000)
-        
+
         result1 = TestResult(group1, true, 5.0, "passing.log", nothing, start_time, start_time + Millisecond(5000))
         result2 = TestResult(group2, false, 3.0, "failing.log", "Test failed", start_time + Millisecond(5000), end_time)
-        
+
         summary = TestSummary(2, 1, 1, 8.0, [result1, result2], start_time, end_time)
-        
+
         # Test report generation without file output
         report = generate_test_summary_report(summary)
         @test occursin("MULTIPROCESS TEST SUMMARY REPORT", report)
@@ -153,14 +153,14 @@ using Distributed
         @test occursin("PassingGroup", report)
         @test occursin("FailingGroup", report)
         @test occursin("FAILED GROUPS SUMMARY", report)
-        
+
         # Test report generation with file output
         temp_file = tempname() * ".txt"
         try
             report_from_file = generate_test_summary_report(summary, temp_file)
             @test isfile(temp_file)
             @test report == report_from_file
-            
+
             file_content = read(temp_file, String)
             @test file_content == report
         finally
@@ -173,14 +173,14 @@ using Distributed
         group = TestGroup("TestGroup")
         result = TestResult(group, true, 5.0, "test.log", nothing, now(), now())
         summary = TestSummary(1, 1, 0, 5.0, [result], now(), now())
-        
+
         # Capture output
         io = IOBuffer()
         redirect_stdout(io) do
             print_test_summary(summary)
         end
         output = String(take!(io))
-        
+
         @test occursin("TEST SUMMARY", output)
         @test occursin("Total: 1", output)
         @test occursin("Passed: 1", output)
@@ -193,67 +193,73 @@ using Distributed
         temp_dir = mktempdir()
         project_dir = joinpath(temp_dir, "TestPackage")
         mkdir(project_dir)
-        
+
         # Create Project.toml
         project_toml = joinpath(project_dir, "Project.toml")
         open(project_toml, "w") do f
-            write(f, """
-            name = "TestPackage"
-            uuid = "12345678-1234-1234-1234-123456789abc"
-            version = "0.1.0"
-            
-            [deps]
-            Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-            """)
+            write(
+                f, """
+                name = "TestPackage"
+                uuid = "12345678-1234-1234-1234-123456789abc"
+                version = "0.1.0"
+
+                [deps]
+                Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+                """
+            )
         end
-        
+
         # Create test directory and file
         test_dir = joinpath(project_dir, "test")
         mkdir(test_dir)
-        
+
         test_file = joinpath(test_dir, "runtests.jl")
         open(test_file, "w") do f
-            write(f, """
-            using Test
-            
-            # Simple test that depends on GROUP environment variable
-            group = get(ENV, "GROUP", "default")
-            
-            @testset "Test Group: \$group" begin
-                if group == "FailingGroup"
-                    @test false  # This will fail
-                else
-                    @test true   # This will pass
+            write(
+                f, """
+                using Test
+
+                # Simple test that depends on GROUP environment variable
+                group = get(ENV, "GROUP", "default")
+
+                @testset "Test Group: \$group" begin
+                    if group == "FailingGroup"
+                        @test false  # This will fail
+                    else
+                        @test true   # This will pass
+                    end
                 end
-            end
-            """)
+                """
+            )
         end
-        
+
         # Create a simple CI workflow
         github_dir = joinpath(project_dir, ".github", "workflows")
         mkpath(github_dir)
-        
+
         ci_file = joinpath(github_dir, "CI.yml")
         open(ci_file, "w") do f
-            write(f, """
-            name: CI
-            jobs:
-              test:
-                strategy:
-                  matrix:
-                    group:
-                      - PassingGroup
-                      - FailingGroup
-            """)
+            write(
+                f, """
+                name: CI
+                jobs:
+                  test:
+                    strategy:
+                      matrix:
+                        group:
+                          - PassingGroup
+                          - FailingGroup
+                """
+            )
         end
-        
+
         try
             # Test parsing the workflow
             groups = parse_ci_workflow(ci_file)
             @test length(groups) == 2
             @test any(g -> g.name == "PassingGroup", groups)
             @test any(g -> g.name == "FailingGroup", groups)
-            
+
             # Test setup_test_environment
             original_dir = pwd()
             try
@@ -262,9 +268,9 @@ using Distributed
             finally
                 cd(original_dir)
             end
-            
+
         finally
-            rm(temp_dir, recursive=true)
+            rm(temp_dir, recursive = true)
         end
     end
 
@@ -274,38 +280,38 @@ using Distributed
         open(bad_yaml, "w") do f
             write(f, "invalid: yaml: content: [unclosed")
         end
-        
+
         try
             @test_throws Exception parse_ci_workflow(bad_yaml)
         finally
             rm(bad_yaml)
         end
-        
+
         # Test setup_test_environment with invalid path
         @test_throws ErrorException setup_test_environment("/completely/invalid/path")
     end
 
     @testset "TestGroup environment variable handling" begin
-        group = TestGroup("TestEnv", env_vars=Dict("TEST_VAR" => "test_value"))
-        
+        group = TestGroup("TestEnv", env_vars = Dict("TEST_VAR" => "test_value"))
+
         # Simulate setting and cleaning environment variables
         original_env = copy(ENV)
-        
+
         try
             # Set environment variables
             for (key, value) in group.env_vars
                 ENV[key] = value
             end
-            
+
             @test ENV["TEST_VAR"] == "test_value"
-            
+
             # Clean up environment variables (simulate what run_single_test_group does)
             for key in keys(group.env_vars)
                 delete!(ENV, key)
             end
-            
+
             @test !haskey(ENV, "TEST_VAR")
-            
+
         finally
             # Restore original environment
             empty!(ENV)
@@ -317,34 +323,38 @@ using Distributed
         # Test workflow with no groups
         empty_workflow = tempname() * ".yml"
         open(empty_workflow, "w") do f
-            write(f, """
-            name: CI
-            jobs:
-              test:
-                runs-on: ubuntu-latest
-            """)
+            write(
+                f, """
+                name: CI
+                jobs:
+                  test:
+                    runs-on: ubuntu-latest
+                """
+            )
         end
-        
+
         try
             groups = parse_ci_workflow(empty_workflow)
             @test length(groups) == 0
         finally
             rm(empty_workflow)
         end
-        
+
         # Test workflow with empty groups
         minimal_workflow = tempname() * ".yml"
         open(minimal_workflow, "w") do f
-            write(f, """
-            name: CI
-            jobs:
-              test:
-                strategy:
-                  matrix:
-                    group: []
-            """)
+            write(
+                f, """
+                name: CI
+                jobs:
+                  test:
+                    strategy:
+                      matrix:
+                        group: []
+                """
+            )
         end
-        
+
         try
             groups = parse_ci_workflow(minimal_workflow)
             @test length(groups) == 0

--- a/test/version_check_finder_tests.jl
+++ b/test/version_check_finder_tests.jl
@@ -6,41 +6,45 @@
 
     # Test file with various version checks
     test_file1 = joinpath(test_dir, "test1.jl")
-    write(test_file1, """
-    # Some Julia code with version checks
+    write(
+        test_file1, """
+        # Some Julia code with version checks
 
-    if VERSION >= v"1.6"
-        println("This is old")
-    end
+        if VERSION >= v"1.6"
+            println("This is old")
+        end
 
-    @static if VERSION > v"1.8.0"
-        use_new_feature()
-    end
+        @static if VERSION > v"1.8.0"
+            use_new_feature()
+        end
 
-    if VERSION >= v"1.10"
-        # This should not be detected as obsolete
-        current_lts_feature()
-    end
+        if VERSION >= v"1.10"
+            # This should not be detected as obsolete
+            current_lts_feature()
+        end
 
-    VERSION <= v"1.9" && old_workaround()
+        VERSION <= v"1.9" && old_workaround()
 
-    if VERSION == v"1.7"
-        specific_version_hack()
-    end
+        if VERSION == v"1.7"
+            specific_version_hack()
+        end
 
-    if VERSION >= VersionNumber("1.5")
-        ancient_code()
-    end
-    """)
+        if VERSION >= VersionNumber("1.5")
+            ancient_code()
+        end
+        """
+    )
 
     # Test file without version checks
     test_file2 = joinpath(test_dir, "test2.jl")
-    write(test_file2, """
-    # Clean code without version checks
-    function foo()
-        return 42
-    end
-    """)
+    write(
+        test_file2, """
+        # Clean code without version checks
+        function foo()
+            return 42
+        end
+        """
+    )
 
     @testset "find_version_checks_in_file" begin
         # Test finding checks in file with version checks
@@ -105,7 +109,7 @@
                 "@static if VERSION > v\"1.8.0\"",
                 v"1.8.0",
                 "VERSION > v\"1.8.0\""
-            )
+            ),
         ]
 
         # Write to script
@@ -131,12 +135,12 @@
         org_results = Dict(
             "org/repo1" => [
                 OrgMaintenanceScripts.VersionCheck(
-                "src/main.jl",
-                15,
-                "VERSION >= v\"1.7\"",
-                v"1.7",
-                "VERSION >= v\"1.7\""
-            )
+                    "src/main.jl",
+                    15,
+                    "VERSION >= v\"1.7\"",
+                    v"1.7",
+                    "VERSION >= v\"1.7\""
+                ),
             ],
             "org/repo2" => [
                 OrgMaintenanceScripts.VersionCheck(
@@ -152,7 +156,7 @@
                     "VERSION == v\"1.8\"",
                     v"1.8",
                     "VERSION == v\"1.8\""
-                )
+                ),
             ]
         )
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)