### PR TITLE
Format: apply Runic to fix format check

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,135 +16,135 @@ end
 if GROUP == "All" || GROUP == "Core"
     @testset "OrgMaintenanceScripts.jl" begin
         @testset "Version bumping" begin
-        # Test bump_minor_version
-        @test OrgMaintenanceScripts.bump_minor_version("1.2.3") == "1.3.0"
-        @test OrgMaintenanceScripts.bump_minor_version("0.1.0") == "0.2.0"
-        @test OrgMaintenanceScripts.bump_minor_version("2.10.5") == "2.11.0"
+            # Test bump_minor_version
+            @test OrgMaintenanceScripts.bump_minor_version("1.2.3") == "1.3.0"
+            @test OrgMaintenanceScripts.bump_minor_version("0.1.0") == "0.2.0"
+            @test OrgMaintenanceScripts.bump_minor_version("2.10.5") == "2.11.0"
 
-        # Test invalid version format
-        @test_throws ErrorException OrgMaintenanceScripts.bump_minor_version("1.2")
-        @test_throws ErrorException OrgMaintenanceScripts.bump_minor_version("1.2.3.4")
-    end
-
-    @testset "Project file handling" begin
-        # Create a temporary test project
-        mktempdir() do tmpdir
-            project_path = joinpath(tmpdir, "Project.toml")
-
-            # Test with valid Project.toml
-            project_data = Dict(
-                "name" => "TestPackage",
-                "uuid" => "12345678-1234-1234-1234-123456789012",
-                "version" => "0.1.0"
-            )
-
-            open(project_path, "w") do io
-                TOML.print(io, project_data)
-            end
-
-            result = OrgMaintenanceScripts.update_project_version(project_path)
-            @test !isnothing(result)
-            @test result[1] == "0.1.0"
-            @test result[2] == "0.2.0"
-
-            # Verify file was updated
-            updated_project = TOML.parsefile(project_path)
-            @test updated_project["version"] == "0.2.0"
-
-            # Test with missing version field
-            delete!(updated_project, "version")
-            open(project_path, "w") do io
-                TOML.print(io, updated_project)
-            end
-
-            result = OrgMaintenanceScripts.update_project_version(project_path)
-            @test isnothing(result)
-
-            # Test with non-existent file
-            result = OrgMaintenanceScripts.update_project_version(joinpath(tmpdir, "nonexistent.toml"))
-            @test isnothing(result)
+            # Test invalid version format
+            @test_throws ErrorException OrgMaintenanceScripts.bump_minor_version("1.2")
+            @test_throws ErrorException OrgMaintenanceScripts.bump_minor_version("1.2.3.4")
         end
-    end
 
-    @testset "Repository processing" begin
-        # Create a mock repository structure
-        mktempdir() do tmpdir
-            # Main Project.toml
-            main_project = Dict(
-                "name" => "MainPackage",
-                "uuid" => "12345678-1234-1234-1234-123456789012",
-                "version" => "1.0.0"
-            )
-            open(joinpath(tmpdir, "Project.toml"), "w") do io
-                TOML.print(io, main_project)
-            end
+        @testset "Project file handling" begin
+            # Create a temporary test project
+            mktempdir() do tmpdir
+                project_path = joinpath(tmpdir, "Project.toml")
 
-            # Create lib directory with subpackages
-            lib_dir = joinpath(tmpdir, "lib")
-            mkpath(lib_dir)
-
-            for (i, pkg) in enumerate(["SubPkgA", "SubPkgB"])
-                pkg_dir = joinpath(lib_dir, pkg)
-                mkpath(pkg_dir)
-
-                sub_project = Dict(
-                    "name" => pkg,
-                    "uuid" => "12345678-1234-1234-1234-12345678901$i",
-                    "version" => "0.$i.0"
+                # Test with valid Project.toml
+                project_data = Dict(
+                    "name" => "TestPackage",
+                    "uuid" => "12345678-1234-1234-1234-123456789012",
+                    "version" => "0.1.0"
                 )
-                open(joinpath(pkg_dir, "Project.toml"), "w") do io
-                    TOML.print(io, sub_project)
+
+                open(project_path, "w") do io
+                    TOML.print(io, project_data)
                 end
+
+                result = OrgMaintenanceScripts.update_project_version(project_path)
+                @test !isnothing(result)
+                @test result[1] == "0.1.0"
+                @test result[2] == "0.2.0"
+
+                # Verify file was updated
+                updated_project = TOML.parsefile(project_path)
+                @test updated_project["version"] == "0.2.0"
+
+                # Test with missing version field
+                delete!(updated_project, "version")
+                open(project_path, "w") do io
+                    TOML.print(io, updated_project)
+                end
+
+                result = OrgMaintenanceScripts.update_project_version(project_path)
+                @test isnothing(result)
+
+                # Test with non-existent file
+                result = OrgMaintenanceScripts.update_project_version(joinpath(tmpdir, "nonexistent.toml"))
+                @test isnothing(result)
             end
-
-            # Initialize git repo
-            cd(tmpdir) do
-                run(`git init`)
-                run(`git config user.name "Test User"`)
-                run(`git config user.email "test@example.com"`)
-                run(`git add .`)
-                run(`git commit -m "Initial commit"`)
-            end
-
-            # Test bump_and_register_repo
-            result = bump_and_register_repo(tmpdir)
-
-            @test !isnothing(result)
-            # In test environment, registration will fail since there's no real registry
-            # So we expect all packages to be in the failed list
-            @test basename(tmpdir) in result.failed || basename(tmpdir) in result.registered
-            @test "SubPkgA" in result.failed || "SubPkgA" in result.registered
-            @test "SubPkgB" in result.failed || "SubPkgB" in result.registered
-            # Either all succeed or all fail (in tests, they'll all fail)
-            @test isempty(result.registered) || isempty(result.failed)
-
-            # Verify versions were bumped
-            main_updated = TOML.parsefile(joinpath(tmpdir, "Project.toml"))
-            @test main_updated["version"] == "1.1.0"
-
-            subA_updated = TOML.parsefile(joinpath(lib_dir, "SubPkgA", "Project.toml"))
-            @test subA_updated["version"] == "0.2.0"
-
-            subB_updated = TOML.parsefile(joinpath(lib_dir, "SubPkgB", "Project.toml"))
-            @test subB_updated["version"] == "0.3.0"
         end
-    end
 
-    @testset "Basic functionality (legacy)" begin
-        # Test deprecated functions still exist but warn
-        @test_logs (:warn,) OrgMaintenanceScripts.update_manifests()
-        @test_logs (:warn,) OrgMaintenanceScripts.update_project_tomls()
-    end
+        @testset "Repository processing" begin
+            # Create a mock repository structure
+            mktempdir() do tmpdir
+                # Main Project.toml
+                main_project = Dict(
+                    "name" => "MainPackage",
+                    "uuid" => "12345678-1234-1234-1234-123456789012",
+                    "version" => "1.0.0"
+                )
+                open(joinpath(tmpdir, "Project.toml"), "w") do io
+                    TOML.print(io, main_project)
+                end
 
-    include("formatting_tests.jl")
-    include("min_version_fixer_tests.jl")
-    include("version_check_finder_tests.jl")
-    include("invalidation_analysis_tests.jl")
-    include("import_timing_analysis_tests.jl")
-    include("explicit_imports_fixer_tests.jl")
-    # Temporarily commented out due to syntax error in multiprocess_testing.jl
-    # include("multiprocess_testing_tests.jl")
-    include("documentation_cleanup_tests.jl")
-    # JET/Aqua static analysis runs in the QA group (GROUP=QA -> test/qa.jl).
+                # Create lib directory with subpackages
+                lib_dir = joinpath(tmpdir, "lib")
+                mkpath(lib_dir)
+
+                for (i, pkg) in enumerate(["SubPkgA", "SubPkgB"])
+                    pkg_dir = joinpath(lib_dir, pkg)
+                    mkpath(pkg_dir)
+
+                    sub_project = Dict(
+                        "name" => pkg,
+                        "uuid" => "12345678-1234-1234-1234-12345678901$i",
+                        "version" => "0.$i.0"
+                    )
+                    open(joinpath(pkg_dir, "Project.toml"), "w") do io
+                        TOML.print(io, sub_project)
+                    end
+                end
+
+                # Initialize git repo
+                cd(tmpdir) do
+                    run(`git init`)
+                    run(`git config user.name "Test User"`)
+                    run(`git config user.email "test@example.com"`)
+                    run(`git add .`)
+                    run(`git commit -m "Initial commit"`)
+                end
+
+                # Test bump_and_register_repo
+                result = bump_and_register_repo(tmpdir)
+
+                @test !isnothing(result)
+                # In test environment, registration will fail since there's no real registry
+                # So we expect all packages to be in the failed list
+                @test basename(tmpdir) in result.failed || basename(tmpdir) in result.registered
+                @test "SubPkgA" in result.failed || "SubPkgA" in result.registered
+                @test "SubPkgB" in result.failed || "SubPkgB" in result.registered
+                # Either all succeed or all fail (in tests, they'll all fail)
+                @test isempty(result.registered) || isempty(result.failed)
+
+                # Verify versions were bumped
+                main_updated = TOML.parsefile(joinpath(tmpdir, "Project.toml"))
+                @test main_updated["version"] == "1.1.0"
+
+                subA_updated = TOML.parsefile(joinpath(lib_dir, "SubPkgA", "Project.toml"))
+                @test subA_updated["version"] == "0.2.0"
+
+                subB_updated = TOML.parsefile(joinpath(lib_dir, "SubPkgB", "Project.toml"))
+                @test subB_updated["version"] == "0.3.0"
+            end
+        end
+
+        @testset "Basic functionality (legacy)" begin
+            # Test deprecated functions still exist but warn
+            @test_logs (:warn,) OrgMaintenanceScripts.update_manifests()
+            @test_logs (:warn,) OrgMaintenanceScripts.update_project_tomls()
+        end
+
+        include("formatting_tests.jl")
+        include("min_version_fixer_tests.jl")
+        include("version_check_finder_tests.jl")
+        include("invalidation_analysis_tests.jl")
+        include("import_timing_analysis_tests.jl")
+        include("explicit_imports_fixer_tests.jl")
+        # Temporarily commented out due to syntax error in multiprocess_testing.jl
+        # include("multiprocess_testing_tests.jl")
+        include("documentation_cleanup_tests.jl")
+        # JET/Aqua static analysis runs in the QA group (GROUP=QA -> test/qa.jl).
     end
 end


### PR DESCRIPTION
Formatting-only PR to fix the failing Runic format check.

The repo's `format-check` CI runs Runic (`fredrikekre/runic-action@v1` / `SciML/.github/.github/workflows/runic.yml@v1`) with default settings (extensions `jl`, no docstring formatting). The check is currently failing.

This applies Runic v1.7.0 (the version `version: '1'` resolves to) in place over all git-tracked `.jl` files, matching exactly how CI selects and formats files. No semantic/code changes — verified that diffs are whitespace/formatting only (`git diff --ignore-all-space` is empty for the larger reindent). Re-running Runic in `--check` mode after formatting passes with exit code 0.

Ignore until reviewed by @ChrisRackauckas.