### PR TITLE
Format for Runic v1.10

### DIFF
--- a/src/import_timing_analysis.jl
+++ b/src/import_timing_analysis.jl
@@ -590,14 +590,14 @@ function write_import_timing_report(report::ImportTimingReport, output_file::Str
         "raw_output" => report.raw_output,
         "major_contributors" => [
             Dict(
-                    "package_name" => timing.package_name,
-                    "total_time" => timing.total_time,
-                    "precompile_time" => timing.precompile_time,
-                    "load_time" => timing.load_time,
-                    "dependencies" => timing.dependencies,
-                    "dep_count" => timing.dep_count,
-                    "is_local" => timing.is_local
-                ) for timing in report.major_contributors
+                "package_name" => timing.package_name,
+                "total_time" => timing.total_time,
+                "precompile_time" => timing.precompile_time,
+                "load_time" => timing.load_time,
+                "dependencies" => timing.dependencies,
+                "dep_count" => timing.dep_count,
+                "is_local" => timing.is_local
+            ) for timing in report.major_contributors
         ]
     )
 

--- a/src/invalidation_analysis.jl
+++ b/src/invalidation_analysis.jl
@@ -554,14 +554,14 @@ function write_invalidation_report(report::InvalidationReport, output_file::Stri
         "recommendations" => report.recommendations,
         "major_invalidators" => [
             Dict(
-                    "method" => inv.method,
-                    "file" => inv.file,
-                    "line" => inv.line,
-                    "package" => inv.package,
-                    "reason" => inv.reason,
-                    "children_count" => inv.children_count,
-                    "depth" => inv.depth
-                ) for inv in report.major_invalidators
+                "method" => inv.method,
+                "file" => inv.file,
+                "line" => inv.line,
+                "package" => inv.package,
+                "reason" => inv.reason,
+                "children_count" => inv.children_count,
+                "depth" => inv.depth
+            ) for inv in report.major_invalidators
         ]
     )
 


### PR DESCRIPTION
## What changed and why

Runic v1.10.0 changed multiline generator-element indentation. This PR applies the formatter output required by that release; it contains no behavioral, dependency, or public-API changes.

**Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Verification

Failing before formatting at `e20b283b5cd8`:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 1]
```

Passing after formatting:

```console
$ ~/.juliaup/bin/julia +release --startup-file=no --project=@runic -m Runic --check .
[exit 0]
$ git diff HEAD^ --check
[exit 0]
$ typos src/import_timing_analysis.jl src/invalidation_analysis.jl
[exit 0]
$ GROUP=QA ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
QA/qa.jl: 32 passed; package tests passed
$ GROUP=All ~/.juliaup/bin/julia +release --startup-file=no --project -e 'using Pkg; Pkg.test()'
Public API 6/6 and version-check finder 23/23 passed; package tests passed
```

## Not verified

- Docs were not built because no docstring, `docs/`, or public API changed.
- GPU, downstream, and allowed-to-fail jobs were not run locally.

## Reviewer note

This is a mechanical Runic-only change; the source diff should be reviewed as formatting output.

🤖 Generated with Codex CLI 0.151.0 (model: unknown; session: local session ID 01a04fa1-cfe0-7260-b416-72fe8a15d17d)