### PR TITLE
Remove x86 CI lane (HTTP TLS precompile broken on i686)

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -4,15 +4,10 @@
 #
 # Core reproduces the previous CI matrix (Julia 1.10 == "lts", and "1").
 # QA runs Aqua/JET static analysis in an isolated environment (test/qa).
+# No x86 lane: HTTP/Reseau TLS precompile fails on i686 ("unexpected resumed state").
 
 [Core]
 versions = ["lts", "1"]
-
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
 
 [QA]
 versions = ["lts", "1"]


### PR DESCRIPTION
## Summary
- Core x86 fails precompiling HTTP/Reseau: `TLS precompile workload observed an unexpected resumed state`.
- Platform/TLS stack gap on i686 — drop hard-fail x86 lane.

## Test plan
- [ ] Remaining Core/QA lanes green


Made with [Cursor](https://cursor.com)